### PR TITLE
Allow localhost to be recognised as a valid hostname

### DIFF
--- a/src/webauthn/webauthn-model.ts
+++ b/src/webauthn/webauthn-model.ts
@@ -13,8 +13,8 @@ export class RpId {
 
   /** @see https://www.w3.org/TR/webauthn-3/#sctn-validating-origin */
   public validate(origin: string): boolean {
-    const parsedOrigin = parse(origin);
-    const parsedRpId = parse(this.value);
+    const parsedOrigin = parse(origin, { validHosts: ['localhost'] });
+    const parsedRpId = parse(this.value, { validHosts: ['localhost'] });
 
     return Boolean(
       parsedOrigin.domain &&

--- a/src/webauthn/webauthn-model.ts
+++ b/src/webauthn/webauthn-model.ts
@@ -13,8 +13,8 @@ export class RpId {
 
   /** @see https://www.w3.org/TR/webauthn-3/#sctn-validating-origin */
   public validate(origin: string): boolean {
-    const parsedOrigin = parse(origin, { validHosts: ['localhost'] });
-    const parsedRpId = parse(this.value, { validHosts: ['localhost'] });
+    const parsedOrigin = parse(origin, { validHosts: ["localhost"] });
+    const parsedRpId = parse(this.value, { validHosts: ["localhost"] });
 
     return Boolean(
       parsedOrigin.domain &&


### PR DESCRIPTION
localhost は Secure Context としてブラウザは認識しており、実際にブラウザ上でWebAuthnの機能利用は可能だが、tldtsでは正しいホスト名として認識されない状態であるため、本エミュレーターでは利用できない状態です。
localhostに対するWebAuthnをエミュレートできるよう、認識されるように変更したいと考えております。


そもそも、WebAuthnの仕様上は https://www.w3.org/TR/webauthn-2/#rp-id 上に以下のように書かれており、これを基にするとlocalhostはeffective domainなのかどうかという点と、localhostかつhttpである場合についてという二つの点が問題になると考えています。
> The [RP ID](https://www.w3.org/TR/webauthn-2/#rp-id) must be equal to the [origin](https://www.w3.org/TR/webauthn-2/#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised)'s [effective domain](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-effective-domain), or a [registrable domain suffix](https://html.spec.whatwg.org/multipage/origin.html#is-a-registrable-domain-suffix-of-or-is-equal-to) of the [origin](https://www.w3.org/TR/webauthn-2/#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised)'s [effective domain](https://html.spec.whatwg.org/multipage/origin.html#concept-origin-effective-domain).
> The [origin](https://www.w3.org/TR/webauthn-2/#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised)'s [scheme](https://url.spec.whatwg.org/#concept-url-scheme) must be https.
> The [origin](https://www.w3.org/TR/webauthn-2/#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised)'s [port](https://url.spec.whatwg.org/#concept-url-port) is unrestricted.

実際localhostで開発用に試験する場合はこれらの条件を満たしていないと思いますので、WebAuthnの本来仕様上はlocalhostが認められない前提で書かれていると考えてよいのかなと思います。

ただし、実際のブラウザの実装は異なります。
Chromeでは、（ソースコードまで確認したわけではないですが挙動として）、WebAuthnが動作する条件としてSecure Contexts[(MDN)](https://developer.mozilla.org/ja/docs/Web/Security/Secure_Contexts)[(W3C)](https://www.w3.org/TR/secure-contexts/)であるかという点を判断条件にしているようです。
併せて、[WebAuthnについてのMDN](https://developer.mozilla.org/ja/docs/Web/API/Web_Authentication_API)においても、利用にはSecure Contextsが必要、と記載があります。

これを考えるとき、任意のポート番号のhttpでのlocalhostあてのWebAuthnは、利用可能であったほうが嬉しいと考えて、Pull Requestとさせていただければと思いました。

ご検討いただけますと幸いです。



なお、TLDTS側は本挙動についてバグではなく仕様と判断しています。
（ localhostはTLDとしては不適切であることから、TLDTSでlocalhostを認める場合は特別な設定をする必要がある、と記載があります ）
https://www.npmjs.com/package/tldts#user-content-retrieving-subdomain-of-localhost-and-custom-hostnames