### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Nikkei/nid-webauthn-emulator/security/code-scanning/3](https://github.com/Nikkei/nid-webauthn-emulator/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it primarily involves installing dependencies, building the project, and running tests. These tasks typically only require read access to the repository contents. Therefore, the `permissions` block should be added at the root level of the workflow to apply to all jobs, and it should specify `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
