### PR TITLE
fix: Fix the type of clientDataHash

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
   "files": {
     "includes": ["**", "!**/node_modules/**", "!**/dist/**", "!**/src/third-party-libs/**", "!**/coverage/**"]
   },

--- a/src/webauthn/webauthn-emulator.ts
+++ b/src/webauthn/webauthn-emulator.ts
@@ -277,7 +277,7 @@ export class WebAuthnEmulator {
     const clientDataJSON = JSON.stringify(clientData);
 
     const authenticatorRequest = packMakeCredentialRequest({
-      clientDataHash: createHash("sha256").update(clientDataJSON).digest(),
+      clientDataHash: EncodeUtils.bufferSourceToUint8Array(createHash("sha256").update(clientDataJSON).digest()),
       rp: { name: options.publicKey.rp.name, id: rpId.value },
       user: options.publicKey.user,
       pubKeyCredParams: options.publicKey.pubKeyCredParams,


### PR DESCRIPTION
The `node-crypto` library returns `Buffer` but the required type is `Uint8Array`