### PR TITLE
chore: biome.json のスキーマ定義を biome のバージョンに追従させる

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "includes": ["**", "!**/node_modules/**", "!**/dist/**", "!**/src/third-party-libs/**", "!**/coverage/**"]
   },


### PR DESCRIPTION
`node_modules` 以下のスキーマ定義を参照させるようにしました