### PR TITLE
Add CTAP2 hmac-secret extension (WebAuthn PRF) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ const authenticator = new AuthenticatorEmulator({
     userPresent: false,
   },
   signCounterIncrement: 0,
+  hmacSecret: "hmac-secret-mc",
 });
 
 const webAuthnEmulator = new WebAuthnEmulator(authenticator);
 ```
+
+The `hmacSecret` option controls the CTAP2 extension that backs the WebAuthn [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension). Use `"hmac-secret"` to evaluate at authentication, `"hmac-secret-mc"` (CTAP 2.2) to also evaluate at registration, or `"none"` to disable (default).
 
 `AuthenticatorEmulator` implements the following commands from the FIDO2/CTAP specification:
 

--- a/docs/authenticator-emulator.en.md
+++ b/docs/authenticator-emulator.en.md
@@ -44,7 +44,7 @@ The emulator implements the CTAP2 `hmac-secret` extension, which backs the WebAu
 
 - **`"none"`**: the extension is neither advertised by `authenticatorGetInfo` nor processed.
 - **`"hmac-secret"`**: advertised by `authenticatorGetInfo`. At `authenticatorMakeCredential` the authenticator generates a 32-byte secret (`CredRandom`) and stores it with the credential. At `authenticatorGetAssertion` it returns `HMAC-SHA-256(CredRandom, salt)` for each requested salt (32 byte input for one salt, 64 for two).
-- **`"hmac-secret-mc"`**: additionally advertises `hmac-secret-mc` and evaluates salts supplied at `authenticatorMakeCredential` (CTAP 2.2) in additional to `authenticatorGetAssertion`.
+- **`"hmac-secret-mc"`**: additionally advertises `hmac-secret-mc` and evaluates salts supplied at `authenticatorMakeCredential` (CTAP 2.2) in addition to `authenticatorGetAssertion`.
 
 `CredRandom` is persisted with the credential so that assertions reproduce the same outputs for the same salts across emulator instances.
 
@@ -63,7 +63,7 @@ Uses the `AuthenticationEmulatorError` class to return error codes based on the 
 
 2. Actual implementations may require more stringent security checks and production-appropriate settings.
 
-3. This emulator covers the basic functionality of the FIDO2/WebAuthn specification, including the the `hmac-secret` extension (see [HMAC Secret Extension](#hmac-secret-extension)). It does not support all advanced features or extensions.
+3. This emulator covers the basic functionality of the FIDO2/WebAuthn specification, including the `hmac-secret` extension (see [HMAC Secret Extension](#hmac-secret-extension)). It does not support all advanced features or extensions.
 
 ## Customization
 

--- a/docs/authenticator-emulator.en.md
+++ b/docs/authenticator-emulator.en.md
@@ -13,15 +13,12 @@ A class that emulates the main functionality of an Authenticator based on the CT
 #### Key Methods
 
 1. `command(request: CTAPAuthenticatorRequest): CTAPAuthenticatorResponse`
-
    - Receives CTAP commands and returns appropriate responses.
 
 2. `authenticatorGetInfo(): AuthenticatorGetInfoResponse`
-
    - Returns information about the Authenticator.
 
 3. `authenticatorMakeCredential(request: AuthenticatorMakeCredentialRequest): AuthenticatorMakeCredentialResponse`
-
    - Creates new credentials.
 
 4. `authenticatorGetAssertion(request: AuthenticatorGetAssertionRequest): AuthenticatorGetAssertionResponse`
@@ -41,6 +38,16 @@ A class that emulates the main functionality of an Authenticator based on the CT
 
 6. **Stateless Mode**: Processes each command independently without maintaining Authenticator state.
 
+## HMAC Secret Extension
+
+The emulator implements the CTAP2 `hmac-secret` extension, which backs the WebAuthn PRF extension. It is selected with the `hmacSecret` parameter and defaults to `"none"`:
+
+- **`"none"`**: the extension is neither advertised by `authenticatorGetInfo` nor processed.
+- **`"hmac-secret"`**: advertised by `authenticatorGetInfo`. At `authenticatorMakeCredential` the authenticator generates a 32-byte secret (`CredRandom`) and stores it with the credential. At `authenticatorGetAssertion` it returns `HMAC-SHA-256(CredRandom, salt)` for each requested salt (32 byte input for one salt, 64 for two).
+- **`"hmac-secret-mc"`**: additionally advertises `hmac-secret-mc` and evaluates salts supplied at `authenticatorMakeCredential` (CTAP 2.2) in additional to `authenticatorGetAssertion`.
+
+`CredRandom` is persisted with the credential so that assertions reproduce the same outputs for the same salts across emulator instances.
+
 ## Security Considerations
 
 - Exclude list and allow list processing: Performs appropriate credential filtering during credential creation and authentication.
@@ -56,7 +63,7 @@ Uses the `AuthenticationEmulatorError` class to return error codes based on the 
 
 2. Actual implementations may require more stringent security checks and production-appropriate settings.
 
-3. This emulator covers the basic functionality of the FIDO2/WebAuthn specification, but does not support all advanced features or extensions.
+3. This emulator covers the basic functionality of the FIDO2/WebAuthn specification, including the the `hmac-secret` extension (see [HMAC Secret Extension](#hmac-secret-extension)). It does not support all advanced features or extensions.
 
 ## Customization
 
@@ -70,6 +77,7 @@ Using `AuthenticatorParameters`, you can customize the following items:
 - User interaction simulation
 - Credential storage method
 - Stateless mode activation
+- HMAC secret extension mode
 
 ## Usage Example
 

--- a/docs/webauthn-emulator.en.md
+++ b/docs/webauthn-emulator.en.md
@@ -66,8 +66,8 @@ const {first, second} = credential.getClientExtensionResults().prf!.results;
 The `hmacSecret` option passed to the `AuthenticatorEmulator` controls when `getClientExtensionResults().prf` contains resulting keys:
 
 - **`"none"`**: (default) the PRF extension is disabled and returns no keys.
-- **`"hmac-secret"`**: `create` sets `prf.enabled` to `true` but returns no results keys. `get` returns keys in `prf.results`.
-- **`"hmac-secret-mc"`**: `create` sets `prf.enabled` to `true` and returns keys in `prf.results`. `get` returns keys in `prf.results`.
+- **`"hmac-secret"`**: `create` sets `prf.enabled` to `true` but returns no extension `prf.results`. `get` returns keys in extension `prf.results`.
+- **`"hmac-secret-mc"`**: `create` sets `prf.enabled` to `true` and returns keys in extension `prf.results`. `get` returns keys in extension `prf.results`.
 
 The JSON variants `createJSON` and `getJSON` take the same inputs as base64url strings and return `prf.results` as base64url strings.
 

--- a/docs/webauthn-emulator.en.md
+++ b/docs/webauthn-emulator.en.md
@@ -13,23 +13,18 @@ A class that mimics the main functionality of the WebAuthn protocol.
 #### Key Methods
 
 1. `getJSON(origin: string, optionsJSON: PublicKeyCredentialRequestOptionsJSON): AuthenticationResponseJSON`
-
    - Processes authentication requests and returns responses in JSON format.
 
 2. `createJSON(origin: string, optionsJSON: PublicKeyCredentialCreationOptionsJSON): RegistrationResponseJSON`
-
    - Processes credential creation requests and returns responses in JSON format.
 
 3. `getAuthenticatorInfo(): AuthenticatorInfo`
-
    - Retrieves authenticator information.
 
 4. `signalUnknownCredential(options: UnknownCredentialOptionsJSON): void`
-
    - Signals unknown credentials and removes them from the authenticator.
 
 5. `get(origin: string, options: CredentialRequestOptions): RequestPublicKeyCredential`
-
    - Simulates the authentication process.
 
 6. `create(origin: string, options: CredentialCreationOptions): CreatePublicKeyCredential`
@@ -43,7 +38,38 @@ A class that mimics the main functionality of the WebAuthn protocol.
 
 3. **JSON Compatibility**: The `getJSON` and `createJSON` methods enable processing of requests and responses in JSON format.
 
-4. **Authenticator Information**: The `getAuthenticatorInfo` method allows you to obtain detailed information about the Authenticator.
+4. **WebAuthn PRF Extension**: The `create`, `get`, `createJSON`, and `getJSON` functions handle PRF requests with an hmacSecret enabled Authenticator.
+
+5. **Authenticator Information**: The `getAuthenticatorInfo` method allows you to obtain detailed information about the Authenticator.
+
+## PRF Extension
+
+`create`, `createJSON`, `get`and `getJSON` support the WebAuthn [PRF extension](https://www.w3.org/TR/webauthn-3/#prf-extension). It requires an `AuthenticatorEmulator` with `hmacSecret` enabled (see the [authenticator emulator docs](authenticator-emulator.en.md)).
+
+Provide inputs through `extensions.prf` and read outputs from `getClientExtensionResults().prf`:
+
+```TypeScript
+const emulator = new WebAuthnEmulator(new AuthenticatorEmulator({ hmacSecret: "hmac-secret-mc" }));
+
+const credential = emulator.create(origin, {
+  publicKey: {
+    ...creationOptions,
+    // first (and optional second) are BufferSource inputs
+    extensions: { prf: { eval: { first: salt1, second: salt2 } } },
+  },
+});
+
+// prf.results are 32 byte ArrayBuffers, stable per salt and credential
+const {first, second} = credential.getClientExtensionResults().prf!.results;
+```
+
+The `hmacSecret` option passed to the `AuthenticatorEmulator` controls when `getClientExtensionResults().prf` contains resulting keys:
+
+- **`"none"`**: (default) the PRF extension is disabled and returns no keys.
+- **`"hmac-secret"`**: `create` sets `prf.enabled` to `true` but returns no results keys. `get` returns keys in `prf.results`.
+- **`"hmac-secret-mc"`**: `create` sets `prf.enabled` to `true` and returns keys in `prf.results`. `get` returns keys in `prf.results`.
+
+The JSON variants `createJSON` and `getJSON` take the same inputs as base64url strings and return `prf.results` as base64url strings.
 
 ## Security Considerations
 
@@ -73,7 +99,7 @@ The WebAuthn emulator maps internal CTAP errors to WebAuthn-facing exceptions.
 
 2. Actual implementations may require more stringent security checks and production-appropriate settings.
 
-3. This emulator covers the basic functionality of the WebAuthn specification, but does not support all advanced features or extensions.
+3. This emulator covers the basic functionality of the WebAuthn specification, including the PRF extension (see [PRF Extension](#prf-extension)). It does not support all advanced features or extensions.
 
 ## Usage Example
 

--- a/spec/authenticator/authenticator-emulator.spec.ts
+++ b/spec/authenticator/authenticator-emulator.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src/authenticator/ctap-model";
 import EncodeUtils from "../../src/libs/encode-utils";
 import { PasskeysCredentialsMemoryRepository } from "../../src/repository/credentials-memory-repository";
+import { unpackAuthenticatorData } from "../../src/webauthn/webauthn-model";
 
 describe("Authenticator Emulator Exceptional Test", () => {
   // Success case has been tested in the webauthn-emulator.spec.ts
@@ -417,5 +418,188 @@ describe("Authenticator Credential Management Tests", () => {
       const call = () => target({ subCommand: CREDENTIAL_MANAGEMENT_SUBCOMMAND.deleteCredential });
       assert.throws(call, new AuthenticationEmulatorError(CTAP_STATUS_CODE.CTAP2_ERR_NOT_ALLOWED));
     });
+  });
+});
+
+describe("hmac-secret extension", () => {
+  const rpId = "example.com";
+  const user = { id: EncodeUtils.strToUint8Array("hmac-user"), name: "user", displayName: "User" };
+  const clientDataHash = new Uint8Array(32).fill(1);
+  const pubKeyCredParams = [{ type: "public-key" as const, alg: -7 }];
+  const salt1 = new Uint8Array(32).fill(2);
+  const salt2 = new Uint8Array(32).fill(3);
+
+  function extensionOutput(authData: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | boolean | undefined {
+    const extensions = unpackAuthenticatorData(authData).extensions as Record<string, unknown> | undefined;
+    return extensions?.["hmac-secret"] as Uint8Array<ArrayBuffer> | boolean | undefined;
+  }
+
+  function assertUint8Array(value: unknown): asserts value is Uint8Array<ArrayBuffer> {
+    if (!(value instanceof Uint8Array)) {
+      assert.fail("expected Uint8Array");
+    }
+  }
+
+  function credentialIdOf(authData: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> {
+    const attested = unpackAuthenticatorData(authData).attestedCredentialData;
+    if (!attested) throw new Error("expected attested credential data");
+    return attested.credentialId;
+  }
+
+  function makeCredential(
+    authenticator: AuthenticatorEmulator,
+    credUser: PublicKeyCredentialUserEntity,
+    extensions?: object,
+  ) {
+    return authenticator.authenticatorMakeCredential({
+      clientDataHash,
+      rp: { id: rpId, name: rpId },
+      user: credUser,
+      pubKeyCredParams,
+      extensions,
+    });
+  }
+
+  function getAssertion(
+    authenticator: AuthenticatorEmulator,
+    credentialId: Uint8Array<ArrayBuffer>,
+    extensions?: object,
+  ) {
+    return authenticator.authenticatorGetAssertion({
+      rpId,
+      clientDataHash,
+      allowList: [{ type: "public-key", id: credentialId }],
+      extensions,
+    });
+  }
+
+  test("authenticator info returns enabled extensions", () => {
+    assert.equal(new AuthenticatorEmulator({ hmacSecret: "none" }).authenticatorGetInfo().extensions, undefined);
+    assert.deepEqual(new AuthenticatorEmulator({ hmacSecret: "hmac-secret" }).authenticatorGetInfo().extensions, [
+      "hmac-secret",
+    ]);
+    assert.deepEqual(new AuthenticatorEmulator({ hmacSecret: "hmac-secret-mc" }).authenticatorGetInfo().extensions, [
+      "hmac-secret",
+      "hmac-secret-mc",
+    ]);
+  });
+
+  test("hmac-secret makeCredential produces matching getAssertion output", () => {
+    const authenticator = new AuthenticatorEmulator({
+      hmacSecret: "hmac-secret",
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    const credential = makeCredential(authenticator, user, { "hmac-secret": true });
+    assert.equal(extensionOutput(credential.authData), true);
+
+    const credentialId = credentialIdOf(credential.authData);
+    const output1 = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    assertUint8Array(output1);
+    assert.equal(output1.length, 32);
+
+    const output2 = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    assert.deepEqual(output2, output1);
+  });
+
+  test("hmac-secret-mc makeCredential produces matching getAssertion output", () => {
+    const authenticator = new AuthenticatorEmulator({
+      hmacSecret: "hmac-secret-mc",
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    const credential = makeCredential(authenticator, user, { "hmac-secret": true, "hmac-secret-mc": salt1 });
+    const output1 = extensionOutput(credential.authData);
+    assertUint8Array(output1);
+
+    const credentialId = credentialIdOf(credential.authData);
+    const output2 = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    assert.deepEqual(output1, output2);
+
+    const output3 = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    assert.deepEqual(output2, output3);
+  });
+
+  test("credRandom survives the stateless credentialId blob", () => {
+    const authenticator = new AuthenticatorEmulator({ hmacSecret: "hmac-secret-mc", stateless: true });
+    const make = makeCredential(authenticator, user, { "hmac-secret": true, "hmac-secret-mc": salt1 });
+    const createOutput = extensionOutput(make.authData);
+    assertUint8Array(createOutput);
+
+    const credentialId = credentialIdOf(make.authData);
+    const assertOutput = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    assert.deepEqual(assertOutput, createOutput);
+  });
+
+  test("output differs per salt and per credential", () => {
+    const authenticator = new AuthenticatorEmulator({
+      hmacSecret: "hmac-secret",
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    const user2 = { id: EncodeUtils.strToUint8Array("hmac-user-2"), name: "user2", displayName: "User Two" };
+    const id1 = credentialIdOf(makeCredential(authenticator, user, { "hmac-secret": true }).authData);
+    const id2 = credentialIdOf(makeCredential(authenticator, user2, { "hmac-secret": true }).authData);
+
+    const out1Salt1 = extensionOutput(getAssertion(authenticator, id1, { "hmac-secret": salt1 }).authData);
+    const out1Salt2 = extensionOutput(getAssertion(authenticator, id1, { "hmac-secret": salt2 }).authData);
+    const out2Salt1 = extensionOutput(getAssertion(authenticator, id2, { "hmac-secret": salt1 }).authData);
+
+    assert.notDeepEqual(out1Salt1, out1Salt2);
+    assert.notDeepEqual(out1Salt1, out2Salt1);
+  });
+
+  test("two salts produce the two concatenated outputs", () => {
+    const authenticator = new AuthenticatorEmulator({
+      hmacSecret: "hmac-secret",
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    const credentialId = credentialIdOf(makeCredential(authenticator, user, { "hmac-secret": true }).authData);
+
+    const both = extensionOutput(
+      getAssertion(authenticator, credentialId, { "hmac-secret": new Uint8Array([...salt1, ...salt2]) }).authData,
+    );
+    assertUint8Array(both);
+    assert.equal(both.length, 64);
+
+    const first = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    const second = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt2 }).authData);
+    assert.deepEqual(both.slice(0, 32), first);
+    assert.deepEqual(both.slice(32), second);
+  });
+
+  test("rejects a salt that is not 32 or 64 bytes", () => {
+    const authenticator = new AuthenticatorEmulator({
+      hmacSecret: "hmac-secret",
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    const credentialId = credentialIdOf(makeCredential(authenticator, user, { "hmac-secret": true }).authData);
+    assert.throws(
+      () => getAssertion(authenticator, credentialId, { "hmac-secret": new Uint8Array(33) }),
+      new AuthenticationEmulatorError(CTAP_STATUS_CODE.CTAP1_ERR_INVALID_PARAMETER),
+    );
+  });
+
+  test("no output for a credential created without hmac-secret", () => {
+    let authenticator = new AuthenticatorEmulator({
+      hmacSecret: "hmac-secret",
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    let credentialId = credentialIdOf(makeCredential(authenticator, user).authData);
+    let output = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    assert.equal(output, undefined);
+
+    authenticator = new AuthenticatorEmulator({
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    credentialId = credentialIdOf(makeCredential(authenticator, user, { "hmac-secret": true }).authData);
+    output = extensionOutput(getAssertion(authenticator, credentialId, { "hmac-secret": salt1 }).authData);
+    assert.equal(output, undefined);
+  });
+
+  test("hmac-secret makeCredential ignores makeCredential salt", () => {
+    const authenticator = new AuthenticatorEmulator({
+      hmacSecret: "hmac-secret",
+      credentialsRepository: new PasskeysCredentialsMemoryRepository(),
+    });
+    const credential = makeCredential(authenticator, user, { "hmac-secret": true, "hmac-secret-mc": salt1 });
+    assert.equal(extensionOutput(credential.authData), true);
   });
 });

--- a/spec/libs/browser-injection.spec.ts
+++ b/spec/libs/browser-injection.spec.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
+import { AuthenticatorEmulator } from "../../src/authenticator/authenticator-emulator";
+import EncodeUtils from "../../src/libs/encode-utils";
 import { HookWebAuthnApis } from "../../src/test-utils/browser-injection";
+import { WebAuthnEmulator } from "../../src/webauthn/webauthn-emulator";
 
 describe("Browser Injection Test", () => {
   test("Browser Injection Test", async () => {
@@ -17,5 +20,62 @@ describe("Browser Injection Test", () => {
     assert.notEqual(window.navigator.credentials.create, undefined);
     assert.notEqual(window.navigator.credentials.get, undefined);
     assert.notEqual(PublicKeyCredential.signalUnknownCredential, undefined);
+  });
+
+  // The hooked create/get run in-page, so every helper they reach must be exported.
+  test("hooked create and get round-trip prf through the emulator", async () => {
+    const origin = "https://test-rp.org";
+    const emulator = new WebAuthnEmulator(new AuthenticatorEmulator({ hmacSecret: "hmac-secret-mc" }));
+
+    const window: {
+      navigator: {
+        credentials: {
+          create?: (options: { publicKey: unknown }) => Promise<PublicKeyCredential>;
+          get?: (options: { publicKey: unknown }) => Promise<PublicKeyCredential>;
+        };
+      };
+      webAuthnEmulatorCreate: (
+        optionsJSON: PublicKeyCredentialCreationOptionsJSON,
+      ) => Promise<RegistrationResponseJSON>;
+      webAuthnEmulatorGet: (optionsJSON: PublicKeyCredentialRequestOptionsJSON) => Promise<AuthenticationResponseJSON>;
+    } = {
+      navigator: { credentials: { create: undefined, get: undefined } },
+      webAuthnEmulatorCreate: async (optionsJSON) => emulator.createJSON(origin, optionsJSON),
+      webAuthnEmulatorGet: async (optionsJSON) => emulator.getJSON(origin, optionsJSON),
+    };
+    const PublicKeyCredential = { isConditionalMediationAvailable: async () => false };
+
+    // biome-ignore lint/security/noGlobalEval: This is a test code.
+    eval(HookWebAuthnApis);
+    assert.ok(await PublicKeyCredential.isConditionalMediationAvailable());
+
+    const first = EncodeUtils.strToUint8Array("prf-input-first");
+    const create = window.navigator.credentials.create;
+    assert.ok(create);
+    const created = await create({
+      publicKey: {
+        rp: { id: "test-rp.org", name: "rp" },
+        user: { id: EncodeUtils.strToUint8Array("user"), name: "user", displayName: "user" },
+        challenge: EncodeUtils.strToUint8Array("challenge"),
+        pubKeyCredParams: [{ alg: -7, type: "public-key" }],
+        extensions: { prf: { eval: { first } } },
+      },
+    });
+    const createdPrf = created.getClientExtensionResults().prf?.results?.first;
+    assert.ok(createdPrf instanceof ArrayBuffer);
+    assert.equal(createdPrf.byteLength, 32);
+
+    const get = window.navigator.credentials.get;
+    assert.ok(get);
+    const asserted = await get({
+      publicKey: {
+        rpId: "test-rp.org",
+        challenge: EncodeUtils.strToUint8Array("challenge-2"),
+        extensions: { prf: { eval: { first } } },
+      },
+    });
+    const assertedPrf = asserted.getClientExtensionResults().prf?.results?.first;
+    assert.ok(assertedPrf instanceof ArrayBuffer);
+    assert.deepEqual(new Uint8Array(assertedPrf), new Uint8Array(createdPrf));
   });
 });

--- a/spec/libs/cbor.spec.ts
+++ b/spec/libs/cbor.spec.ts
@@ -82,6 +82,18 @@ describe("CBOR encode/decode edge cases", () => {
     assert.equal(EncodeUtils.decodeCbor<null>(new Uint8Array([0xf6])), null);
   });
 
+  test("decodeCborWithRemainder returns the first value and trailing bytes", () => {
+    const first = EncodeUtils.encodeCbor({ 1: "a", [-2]: new Uint8Array([9, 9]) });
+    const second = EncodeUtils.encodeCbor({ 2: "b" });
+    const combined = new Uint8Array([...first, ...second]);
+
+    const { value, remainder } = EncodeUtils.decodeCborWithRemainder<Record<string | number, unknown>>(combined);
+
+    assert.equal(value[1], "a");
+    assert.deepEqual(value[-2], new Uint8Array([9, 9]));
+    assert.deepEqual(remainder, second);
+  });
+
   test("rejects unsupported values and malformed input", () => {
     assert.throws(() => EncodeUtils.encodeCbor(Symbol("unsupported") as unknown as object), {
       message: "Unsupported CBOR value type: symbol",

--- a/spec/webauthn/webauthn-emulator.spec.ts
+++ b/spec/webauthn/webauthn-emulator.spec.ts
@@ -939,7 +939,7 @@ describe("WebAuthnEmulator PRF extension", () => {
     assert.deepEqual(prfResults(assertion), createResults);
   });
 
-  test("evalByCredential returns each credential's result and nothing on a mismatch", () => {
+  test("evalByCredential returns each credential's result", () => {
     const emulator = prfEmulator("hmac-secret-mc");
     const userA = { id: EncodeUtils.strToUint8Array("prf-user-a"), name: "a", displayName: "A" };
     const userB = { id: EncodeUtils.strToUint8Array("prf-user-b"), name: "b", displayName: "B" };
@@ -959,15 +959,6 @@ describe("WebAuthnEmulator PRF extension", () => {
     });
     assert.deepEqual(prfResults(assertedA), resultsA);
     assert.deepEqual(prfResults(assertedB), resultsB);
-
-    const mismatchedA = assertCredential(emulator, credentialA.rawId, {
-      prf: { evalByCredential: { [idBB64]: { first: inputB } } },
-    });
-    const mismatchedB = assertCredential(emulator, credentialB.rawId, {
-      prf: { evalByCredential: { [idAB64]: { first: inputA } } },
-    });
-    assert.equal(mismatchedA.getClientExtensionResults().prf, undefined);
-    assert.equal(mismatchedB.getClientExtensionResults().prf, undefined);
   });
 
   test("evalByCredential without allowCredentials throws NotSupportedError", () => {
@@ -978,6 +969,34 @@ describe("WebAuthnEmulator PRF extension", () => {
           publicKey: { rpId, challenge, extensions: { prf: { evalByCredential: { AAAA: { first: inputA } } } } },
         }),
       { name: "NotSupportedError" },
+    );
+  });
+
+  test("evalByCredential during creation throws NotSupportedError", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    assert.throws(() => createCredential(emulator, { prf: { evalByCredential: { AAAA: { first: inputA } } } }), {
+      name: "NotSupportedError",
+    });
+  });
+
+  test("evalByCredential with a key not in allowCredentials throws SyntaxError", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    const credential = createCredential(emulator, { prf: { eval: { first: inputA } } });
+    const foreignKey = EncodeUtils.encodeBase64Url(EncodeUtils.strToUint8Array("not-a-listed-credential"));
+    for (const badKey of ["", "!not base64!", foreignKey]) {
+      assert.throws(
+        () =>
+          assertCredential(emulator, credential.rawId, { prf: { evalByCredential: { [badKey]: { first: inputA } } } }),
+        { name: "SyntaxError" },
+      );
+    }
+  });
+
+  test("empty evalByCredential does not require allowCredentials", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    createCredential(emulator, { prf: { eval: { first: inputA } } });
+    assert.doesNotThrow(() =>
+      emulator.get(rpOrigin, { publicKey: { rpId, challenge, extensions: { prf: { evalByCredential: {} } } } }),
     );
   });
 

--- a/spec/webauthn/webauthn-emulator.spec.ts
+++ b/spec/webauthn/webauthn-emulator.spec.ts
@@ -1,19 +1,26 @@
-import assert from "node:assert/strict";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, test } from "node:test";
 import WebAuthnEmulator, {
   AuthenticationEmulatorError,
   AuthenticatorEmulator,
+  type CreatePublicKeyCredential,
   CTAP_COMMAND,
   CTAP_STATUS_CODE,
   type CTAPAuthenticatorRequest,
   type CTAPAuthenticatorResponse,
   type PasskeysCredentialsRepository,
   packCredentialManagementResponse,
+  parseCreationOptionsFromJSON,
   parseRequestOptionsFromJSON,
+  type RequestPublicKeyCredential,
   toPublicKeyCredentialDescriptorJSON,
   unpackAuthenticatorData,
 } from "../../src";
 import EncodeUtils from "../../src/libs/encode-utils";
+import { PasskeysCredentialsFileRepository } from "../../src/repository/credentials-file-repository";
 import { PasskeysCredentialsMemoryRepository } from "../../src/repository/credentials-memory-repository";
 import { TEST_RP_ORIGIN, WebAuthnTestServer } from "./webauthn-test-server";
 
@@ -796,5 +803,226 @@ describe("handleAuthenticatorCall other error path", () => {
       assert.ok(e instanceof Error);
       assert.equal((e as Error).message, "Non-CTAP failure");
     }
+  });
+});
+
+describe("WebAuthnEmulator PRF extension", () => {
+  const rpOrigin = "https://test-rp.org";
+  const rpId = "test-rp.org";
+  const user = { id: EncodeUtils.strToUint8Array("prf-user"), name: "user", displayName: "User" };
+  const challenge = EncodeUtils.strToUint8Array("prf-challenge");
+  const pubKeyCredParams = [{ type: "public-key" as const, alg: -7 }];
+  const inputA = EncodeUtils.strToUint8Array("prf-input-a");
+  const inputB = EncodeUtils.strToUint8Array("prf-input-b");
+
+  function prfEmulator(
+    hmacSecret: "none" | "hmac-secret" | "hmac-secret-mc",
+    repository?: PasskeysCredentialsRepository,
+  ): WebAuthnEmulator {
+    const credentialsRepository = repository ?? new PasskeysCredentialsMemoryRepository();
+    return new WebAuthnEmulator(new AuthenticatorEmulator({ hmacSecret, credentialsRepository }));
+  }
+
+  function createCredential(
+    emulator: WebAuthnEmulator,
+    extensions: AuthenticationExtensionsClientInputs,
+    credUser: PublicKeyCredentialUserEntity = user,
+  ): CreatePublicKeyCredential {
+    return emulator.create(rpOrigin, {
+      publicKey: { rp: { id: rpId, name: rpId }, user: credUser, challenge, pubKeyCredParams, extensions },
+    });
+  }
+
+  function assertCredential(
+    emulator: WebAuthnEmulator,
+    credentialId: BufferSource,
+    extensions: AuthenticationExtensionsClientInputs,
+  ): RequestPublicKeyCredential {
+    return emulator.get(rpOrigin, {
+      publicKey: { rpId, challenge, allowCredentials: [{ type: "public-key", id: credentialId }], extensions },
+    });
+  }
+
+  function prfResults(credential: PublicKeyCredential): AuthenticationExtensionsPRFValues {
+    const results = credential.getClientExtensionResults().prf?.results;
+    assert.ok(results);
+    assert.ok(results.first instanceof ArrayBuffer);
+    assert.equal(results.first.byteLength, 32);
+    if (results.second) {
+      assert.ok(results.second instanceof ArrayBuffer);
+      assert.equal(results.second.byteLength, 32);
+    }
+    return results;
+  }
+
+  test("hmac-secret-mc emulator create and get results match", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    const credential = createCredential(emulator, { prf: { eval: { first: inputA, second: inputB } } });
+    assert.equal(credential.getClientExtensionResults().prf?.enabled, true);
+    const createResults = prfResults(credential);
+    assert.ok(createResults.second);
+
+    const credentialId = credential.rawId;
+    const assertion = assertCredential(emulator, credentialId, { prf: { eval: { first: inputA, second: inputB } } });
+    assert.deepEqual(prfResults(assertion), createResults);
+  });
+
+  test("assertCredential produces the same output with and without hmac-secret-mc", () => {
+    const repository = new PasskeysCredentialsMemoryRepository();
+    const credential = createCredential(prfEmulator("hmac-secret-mc", repository), {
+      prf: { eval: { first: inputA } },
+    });
+    const createResults = prfResults(credential);
+    const credentialId = credential.rawId;
+
+    const evalInputs = { prf: { eval: { first: inputA, second: inputB } } };
+    const withMc = prfResults(assertCredential(prfEmulator("hmac-secret-mc", repository), credentialId, evalInputs));
+    const withoutMc = prfResults(assertCredential(prfEmulator("hmac-secret", repository), credentialId, evalInputs));
+
+    assert.ok(withMc.second);
+    assert.deepEqual(withMc.first, createResults.first);
+    assert.deepEqual(withMc, withoutMc);
+  });
+
+  test("hmac-secret only returns results during get", () => {
+    const emulator = prfEmulator("hmac-secret");
+    const credential = createCredential(emulator, { prf: {} });
+    const createResults = credential.getClientExtensionResults();
+    assert.equal(createResults.prf?.enabled, true);
+    assert.equal(createResults.prf?.results, undefined);
+
+    const credentialId = credential.rawId;
+    const assertResults = prfResults(
+      assertCredential(emulator, credentialId, { prf: { eval: { first: inputA, second: inputB } } }),
+    );
+    assert.ok(assertResults.second);
+  });
+
+  test("hmac-secret create with eval returns no key results", () => {
+    const emulator = prfEmulator("hmac-secret");
+    const credential = createCredential(emulator, { prf: { eval: { first: inputA } } });
+    const createResults = credential.getClientExtensionResults();
+    assert.equal(createResults.prf?.enabled, true);
+    assert.equal(createResults.prf?.results, undefined);
+
+    prfResults(assertCredential(emulator, credential.rawId, { prf: { eval: { first: inputA } } }));
+  });
+
+  test("two eval inputs produce two distinct outputs", () => {
+    const emulator = prfEmulator("hmac-secret");
+    const credentialId = createCredential(emulator, { prf: {} }).rawId;
+    const assertResults = prfResults(
+      assertCredential(emulator, credentialId, { prf: { eval: { first: inputA, second: inputB } } }),
+    );
+    assert.ok(assertResults.second);
+    assert.notDeepEqual(assertResults.first, assertResults.second);
+  });
+
+  test("no PRF result with no hmac-secret extension", () => {
+    const emulator = prfEmulator("none");
+    const credential = createCredential(emulator, { prf: {} });
+    assert.equal(credential.getClientExtensionResults().prf?.enabled, false);
+
+    const credentialId = credential.rawId;
+    const assertion = assertCredential(emulator, credentialId, { prf: { eval: { first: inputA } } });
+    assert.equal(assertion.getClientExtensionResults().prf, undefined);
+  });
+
+  test("PRF resolves for a discoverable credential without an allow list", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    const createResults = prfResults(createCredential(emulator, { prf: { eval: { first: inputA, second: inputB } } }));
+
+    // no allowCredentials
+    const assertion = emulator.get(rpOrigin, {
+      publicKey: { rpId, challenge, extensions: { prf: { eval: { first: inputA, second: inputB } } } },
+    });
+    assert.deepEqual(prfResults(assertion), createResults);
+  });
+
+  test("evalByCredential returns each credential's result and nothing on a mismatch", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    const userA = { id: EncodeUtils.strToUint8Array("prf-user-a"), name: "a", displayName: "A" };
+    const userB = { id: EncodeUtils.strToUint8Array("prf-user-b"), name: "b", displayName: "B" };
+
+    const credentialA = createCredential(emulator, { prf: { eval: { first: inputA } } }, userA);
+    const credentialB = createCredential(emulator, { prf: { eval: { first: inputB } } }, userB);
+    const resultsA = prfResults(credentialA);
+    const resultsB = prfResults(credentialB);
+    const idAB64 = EncodeUtils.encodeBase64Url(credentialA.rawId);
+    const idBB64 = EncodeUtils.encodeBase64Url(credentialB.rawId);
+
+    const assertedA = assertCredential(emulator, credentialA.rawId, {
+      prf: { evalByCredential: { [idAB64]: { first: inputA } } },
+    });
+    const assertedB = assertCredential(emulator, credentialB.rawId, {
+      prf: { evalByCredential: { [idBB64]: { first: inputB } } },
+    });
+    assert.deepEqual(prfResults(assertedA), resultsA);
+    assert.deepEqual(prfResults(assertedB), resultsB);
+
+    const mismatchedA = assertCredential(emulator, credentialA.rawId, {
+      prf: { evalByCredential: { [idBB64]: { first: inputB } } },
+    });
+    const mismatchedB = assertCredential(emulator, credentialB.rawId, {
+      prf: { evalByCredential: { [idAB64]: { first: inputA } } },
+    });
+    assert.equal(mismatchedA.getClientExtensionResults().prf, undefined);
+    assert.equal(mismatchedB.getClientExtensionResults().prf, undefined);
+  });
+
+  test("evalByCredential without allowCredentials throws NotSupportedError", () => {
+    const emulator = prfEmulator("hmac-secret");
+    assert.throws(
+      () =>
+        emulator.get(rpOrigin, {
+          publicKey: { rpId, challenge, extensions: { prf: { evalByCredential: { AAAA: { first: inputA } } } } },
+        }),
+      { name: "NotSupportedError" },
+    );
+  });
+
+  test("credRandom persists to a file repository across emulator instances", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prf-file-credentials-"));
+    try {
+      const created = prfEmulator("hmac-secret-mc", new PasskeysCredentialsFileRepository(dir));
+      const credential = createCredential(created, { prf: { eval: { first: inputA, second: inputB } } });
+      const createResults = prfResults(credential);
+      const credentialId = credential.rawId;
+
+      const loaded = prfEmulator("hmac-secret-mc", new PasskeysCredentialsFileRepository(dir));
+      const assertResults = prfResults(
+        assertCredential(loaded, credentialId, { prf: { eval: { first: inputA, second: inputB } } }),
+      );
+      assert.deepEqual(assertResults, createResults);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("hmac-secret-mc PRF works with WebAuthnTestServer", async () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    const testServer = new WebAuthnTestServer();
+    const prfUser = { username: "prf", id: "prf" };
+
+    const regOptions = await testServer.getRegistrationOptions(prfUser);
+    const credential = emulator.create(testServer.origin, {
+      publicKey: {
+        ...parseCreationOptionsFromJSON(regOptions),
+        extensions: { prf: { eval: { first: inputA, second: inputB } } },
+      },
+    });
+    await testServer.getRegistrationVerification(prfUser, credential.toJSON());
+    const createResults = prfResults(credential);
+
+    const authOptions = await testServer.getAuthenticationOptions();
+    const assertion = emulator.get(testServer.origin, {
+      publicKey: {
+        ...parseRequestOptionsFromJSON(authOptions),
+        extensions: { prf: { eval: { first: inputA, second: inputB } } },
+      },
+    });
+    // Verifies the signature over authenticatorData, which now carries the hmac-secret extension.
+    await testServer.getAuthenticationVerification(assertion.toJSON());
+    assert.deepEqual(prfResults(assertion), createResults);
   });
 });

--- a/spec/webauthn/webauthn-emulator.spec.ts
+++ b/spec/webauthn/webauthn-emulator.spec.ts
@@ -1025,4 +1025,59 @@ describe("WebAuthnEmulator PRF extension", () => {
     await testServer.getAuthenticationVerification(assertion.toJSON());
     assert.deepEqual(prfResults(assertion), createResults);
   });
+
+  test("createJSON and getJSON round-trip PRF eval", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    const createOptions: PublicKeyCredentialCreationOptionsJSON = {
+      rp: { id: rpId, name: rpId },
+      user: { id: EncodeUtils.encodeBase64Url(user.id), name: user.name, displayName: user.displayName },
+      challenge: EncodeUtils.encodeBase64Url(challenge),
+      pubKeyCredParams,
+      extensions: {
+        prf: { eval: { first: EncodeUtils.encodeBase64Url(inputA), second: EncodeUtils.encodeBase64Url(inputB) } },
+      },
+    };
+    const credential = emulator.createJSON(rpOrigin, createOptions);
+    const createResults = credential.clientExtensionResults.prf?.results;
+    assert.ok(createResults);
+    assert.ok(createResults.first);
+    assert.ok(createResults.second);
+
+    const requestOptions: PublicKeyCredentialRequestOptionsJSON = {
+      rpId,
+      challenge: EncodeUtils.encodeBase64Url(challenge),
+      allowCredentials: [{ type: "public-key", id: credential.id }],
+      extensions: {
+        prf: { eval: { first: EncodeUtils.encodeBase64Url(inputA), second: EncodeUtils.encodeBase64Url(inputB) } },
+      },
+    };
+    const assertion = emulator.getJSON(rpOrigin, requestOptions);
+    assert.deepEqual(assertion.clientExtensionResults.prf?.results, createResults);
+  });
+
+  test("createJSON and getJSON round-trip PRF evalByCredential", () => {
+    const emulator = prfEmulator("hmac-secret-mc");
+    const createOptions: PublicKeyCredentialCreationOptionsJSON = {
+      rp: { id: rpId, name: rpId },
+      user: { id: EncodeUtils.encodeBase64Url(user.id), name: user.name, displayName: user.displayName },
+      challenge: EncodeUtils.encodeBase64Url(challenge),
+      pubKeyCredParams,
+      extensions: { prf: { eval: { first: EncodeUtils.encodeBase64Url(inputA) } } },
+    };
+    const credential = emulator.createJSON(rpOrigin, createOptions);
+    const createResults = credential.clientExtensionResults.prf?.results;
+    assert.ok(createResults);
+    const credentialIdB64 = credential.id;
+
+    const requestOptions: PublicKeyCredentialRequestOptionsJSON = {
+      rpId,
+      challenge: EncodeUtils.encodeBase64Url(challenge),
+      allowCredentials: [{ type: "public-key", id: credentialIdB64 }],
+      extensions: {
+        prf: { evalByCredential: { [credentialIdB64]: { first: EncodeUtils.encodeBase64Url(inputA) } } },
+      },
+    };
+    const assertion = emulator.getJSON(rpOrigin, requestOptions);
+    assert.deepEqual(assertion.clientExtensionResults.prf?.results, createResults);
+  });
 });

--- a/spec/webauthn/webauthn-model-json.spec.ts
+++ b/spec/webauthn/webauthn-model-json.spec.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 
+import { AuthenticatorEmulator } from "../../src/authenticator/authenticator-emulator";
 import EncodeUtils from "../../src/libs/encode-utils";
 import { WebAuthnEmulator } from "../../src/webauthn/webauthn-emulator";
 import {
@@ -31,40 +32,84 @@ describe("WebAuthn JSON Model Test", () => {
     userVerification: "required",
   };
 
+  const creationOptionPrf: PublicKeyCredentialCreationOptions = {
+    ...creationOption,
+    extensions: {
+      prf: {
+        eval: {
+          first: EncodeUtils.strToUint8Array("prf-eval-first"),
+          second: EncodeUtils.strToUint8Array("prf-eval-second"),
+        },
+      },
+    },
+  };
+
+  const requestOptionPrf: PublicKeyCredentialRequestOptions = {
+    ...requestOption,
+    extensions: {
+      prf: {
+        eval: {
+          first: EncodeUtils.strToUint8Array("prf-eval-first"),
+          second: EncodeUtils.strToUint8Array("prf-eval-second"),
+        },
+      },
+    },
+  };
+
   test("Create Option JSON Serialize Deserialize test", async () => {
-    const json = toCreationOptionsJSON(creationOption);
-    const model = parseCreationOptionsFromJSON(json);
-    const reJson = toCreationOptionsJSON(model);
-    assert.deepEqual(reJson, json);
+    for (const option of [creationOption, creationOptionPrf]) {
+      const json = toCreationOptionsJSON(option);
+      const model = parseCreationOptionsFromJSON(json);
+      const reJson = toCreationOptionsJSON(model);
+      assert.deepEqual(reJson, json);
+    }
   });
 
   test("Create Response JSON Serialize Deserialize test", async () => {
-    const emulator = new WebAuthnEmulator();
-    const response = emulator.create("https://test-rp.org", { publicKey: creationOption });
-
-    const json = toRegistrationResponseJSON(response);
-    const model = parseRegistrationResponseFromJSON(json);
-    const reJson = toRegistrationResponseJSON(model);
-    assert.deepEqual(reJson, json);
+    const cases = [
+      { emulator: new WebAuthnEmulator(), option: creationOption },
+      {
+        emulator: new WebAuthnEmulator(new AuthenticatorEmulator({ hmacSecret: "hmac-secret-mc" })),
+        option: creationOptionPrf,
+      },
+    ];
+    for (const { emulator, option } of cases) {
+      const response = emulator.create("https://test-rp.org", { publicKey: option });
+      const json = toRegistrationResponseJSON(response);
+      const model = parseRegistrationResponseFromJSON(json);
+      const reJson = toRegistrationResponseJSON(model);
+      assert.deepEqual(reJson, json);
+    }
   });
 
   test("Get Option JSON Serialize Deserialize test", async () => {
-    const json = toRequestOptionsJSON(requestOption);
-    const model = parseRequestOptionsFromJSON(json);
-    const reJson = toRequestOptionsJSON(model);
-    assert.deepEqual(reJson, json);
+    for (const option of [requestOption, requestOptionPrf]) {
+      const json = toRequestOptionsJSON(option);
+      const model = parseRequestOptionsFromJSON(json);
+      const reJson = toRequestOptionsJSON(model);
+      assert.deepEqual(reJson, json);
+    }
   });
 
   test("Get Response JSON Serialize Deserialize test", async () => {
-    const emulator = new WebAuthnEmulator();
-    emulator.create("https://test-rp.org", { publicKey: creationOption });
-    const response = emulator.get("https://test-rp.org", {
-      publicKey: { ...requestOption, allowCredentials: undefined },
-    });
-    const json = toAuthenticationResponseJSON(response);
-    const model = parseAuthenticationResponseFromJSON(json);
-    const reJson = toAuthenticationResponseJSON(model);
-    assert.deepEqual(reJson, json);
+    const cases = [
+      { emulator: new WebAuthnEmulator(), createOption: creationOption, getOption: requestOption },
+      {
+        emulator: new WebAuthnEmulator(new AuthenticatorEmulator({ hmacSecret: "hmac-secret-mc" })),
+        createOption: creationOptionPrf,
+        getOption: requestOptionPrf,
+      },
+    ];
+    for (const { emulator, createOption, getOption } of cases) {
+      emulator.create("https://test-rp.org", { publicKey: createOption });
+      const response = emulator.get("https://test-rp.org", {
+        publicKey: { ...getOption, allowCredentials: undefined },
+      });
+      const json = toAuthenticationResponseJSON(response);
+      const model = parseAuthenticationResponseFromJSON(json);
+      const reJson = toAuthenticationResponseJSON(model);
+      assert.deepEqual(reJson, json);
+    }
   });
 
   test("Create Response JSON optional test", async () => {

--- a/spec/webauthn/webauthn-model.spec.ts
+++ b/spec/webauthn/webauthn-model.spec.ts
@@ -50,6 +50,7 @@ describe("WebAuthn Model Test", () => {
         rpIdHash: new Uint8Array(32),
         signCount: 0,
         attestedCredentialData: undefined,
+        extensions: { "hmac-secret": true },
       },
       attStmt: { test: "test123" },
     };
@@ -57,6 +58,29 @@ describe("WebAuthn Model Test", () => {
     const packed = packAttestationObject(testData);
     const unpacked = unpackAttestationObject(packed);
     assert.deepEqual(unpacked, testData);
+  });
+
+  test("Attestation Object pack and unpack with attested credential data and extensions", async () => {
+    const createResponse = webauthnEmulator.create("https://test-rp.org", {
+      publicKey: {
+        rp: { name: "test-rp.org", id: "test-rp.org" },
+        user: { id: EncodeUtils.strToUint8Array("test-user"), name: "user", displayName: "user" },
+        challenge: EncodeUtils.strToUint8Array("challenge"),
+        pubKeyCredParams: [{ alg: -7, type: "public-key" }],
+      },
+    });
+
+    const testData = unpackAttestationObject(new Uint8Array(createResponse.response.attestationObject));
+    testData.authData.flags.extensionData = true;
+    testData.authData.extensions = { "hmac-secret": new Uint8Array(32).fill(9) };
+
+    const packed = packAttestationObject(testData);
+    const unpacked = unpackAttestationObject(packed);
+    assert.deepEqual(unpacked, testData);
+
+    assert.equal(unpacked.authData.flags.extensionData, true);
+    assert.equal(unpacked.authData.flags.attestedCredentialData, true);
+    assert.deepEqual(unpacked.authData.extensions, { "hmac-secret": new Uint8Array(32).fill(9) });
   });
 
   test("Undefined User Handle PublicKey serialize test", async () => {

--- a/spec/webauthn/webauthn-model.spec.ts
+++ b/spec/webauthn/webauthn-model.spec.ts
@@ -66,6 +66,21 @@ describe("WebAuthn Model Test", () => {
       privateKey: new Uint8Array([116, 101, 115, 116, 45, 99]),
       rpId: new RpId("test-rp.org"),
       userHandle: undefined,
+      credRandom: undefined,
+    };
+    const json = toPublickeyCredentialSourceJSON(testData);
+    const model = parsePublicKeyCredentialSourceFromJSON(json);
+    assert.deepEqual(model, testData);
+  });
+
+  test("CredRandom PublicKey serialize test", async () => {
+    const testData: PublicKeyCredentialSource = {
+      type: "public-key",
+      id: new Uint8Array([116, 101, 115, 116, 45, 99]),
+      privateKey: new Uint8Array([116, 101, 115, 116, 45, 99]),
+      rpId: new RpId("test-rp.org"),
+      userHandle: new Uint8Array([1, 2, 3, 4]),
+      credRandom: new Uint8Array(32).fill(1),
     };
     const json = toPublickeyCredentialSourceJSON(testData);
     const model = parsePublicKeyCredentialSourceFromJSON(json);

--- a/src/authenticator/authenticator-emulator.ts
+++ b/src/authenticator/authenticator-emulator.ts
@@ -356,6 +356,7 @@ export class AuthenticatorEmulator {
     const hmacSecret = request.extensions
       ? makeCredentialHmacSecret(this.params.hmacSecret, request.extensions)
       : undefined;
+    const extensions: Record<string, unknown> = { ...hmacSecret?.extension };
     const credential = makeCredential(
       this.params.aaguid,
       rpId,
@@ -364,7 +365,8 @@ export class AuthenticatorEmulator {
       interactionResponse,
       request.user,
       repository ? undefined : AuthenticatorEmulator.ENCRYPT_KEY,
-      hmacSecret,
+      hmacSecret?.credRandom,
+      extensions,
     );
     if (repository) {
       const discoverableCredential: PasskeyDiscoverableCredential = {
@@ -403,13 +405,14 @@ export class AuthenticatorEmulator {
 
     // Get assertion
     const newSignCount = !repository ? 0 : credential.authenticatorData.signCount + this.params.signCounterIncrement;
-    const extension = request.extensions
+    const hmacSecret = request.extensions
       ? getAssertionHmacSecret(
           this.params.hmacSecret,
           request.extensions,
           credential.publicKeyCredentialSource.credRandom,
         )
       : undefined;
+    const extensions: Record<string, unknown> = { ...hmacSecret };
     const { authData, signature } = getAssertion(
       rpId.hash,
       request.clientDataHash,
@@ -417,7 +420,7 @@ export class AuthenticatorEmulator {
       credential.publicKeyCredentialSource,
       interactionResponse,
       !repository,
-      extension,
+      extensions,
     );
 
     // Update sign count
@@ -519,7 +522,7 @@ function getAssertion(
   credential: PublicKeyCredentialSource,
   interactionResponse: InteractionResponse,
   stateless: boolean,
-  extension: HmacSecretExtension | undefined,
+  extensions: object | undefined,
 ): { authData: Uint8Array<ArrayBuffer>; signature: Uint8Array<ArrayBuffer> } {
   const authenticatorData = {
     rpIdHash,
@@ -529,10 +532,10 @@ function getAssertion(
       backupEligibility: !stateless,
       backupState: !stateless,
       attestedCredentialData: false,
-      extensionData: Boolean(extension),
+      extensionData: Boolean(extensions),
     },
     signCount: newSignCounter,
-    extensions: extension,
+    extensions,
   };
 
   const payload: number[] = [];
@@ -607,7 +610,8 @@ function makeCredential(
   interactionResponse: InteractionResponse,
   user: PublicKeyCredentialUserEntity | undefined,
   statelessKey: Uint8Array<ArrayBuffer> | undefined,
-  hmacSecret: HmacSecretResult | undefined,
+  credRandom: Uint8Array<ArrayBuffer> | undefined,
+  extensions: object | undefined,
 ): PasskeyCredential {
   const generatekeyPair = (alg: keyof typeof COSEAlgorithmIdentifier) => {
     if (alg === "RS256") return generateKeyPairSync("rsa", { modulusLength: 2048 });
@@ -618,10 +622,7 @@ function makeCredential(
   const keyPair = generatekeyPair(alg);
   const privateKey = new Uint8Array(keyPair.privateKey.export({ format: "der", type: "pkcs8" }));
   const credentialId = statelessKey
-    ? encryptBytes(
-        statelessKey,
-        EncodeUtils.encodeCbor(hmacSecret ? { privateKey, credRandom: hmacSecret.credRandom } : { privateKey }),
-      )
+    ? encryptBytes(statelessKey, EncodeUtils.encodeCbor(credRandom ? { privateKey, credRandom } : { privateKey }))
     : new Uint8Array(randomBytes(32));
 
   const publicKeyCredentialSource: PublicKeyCredentialSource = {
@@ -630,7 +631,7 @@ function makeCredential(
     privateKey: new Uint8Array(keyPair.privateKey.export({ format: "der", type: "pkcs8" })),
     rpId: rpId,
     userHandle: user && !statelessKey ? EncodeUtils.bufferSourceToUint8Array(user.id) : undefined,
-    credRandom: hmacSecret?.credRandom,
+    credRandom,
   };
 
   const publicKeyCredentialDescriptor: PublicKeyCredentialDescriptor = {
@@ -647,7 +648,7 @@ function makeCredential(
       userPresent: interactionResponse.options.up,
       userVerified: interactionResponse.options.uv,
       attestedCredentialData: true,
-      extensionData: Boolean(hmacSecret),
+      extensionData: Boolean(extensions),
     },
     signCount: 0,
     attestedCredentialData: {
@@ -655,7 +656,7 @@ function makeCredential(
       credentialId,
       credentialPublicKey: CoseKey.fromKeyObject(keyPair.publicKey),
     },
-    extensions: hmacSecret?.extension,
+    extensions,
   };
   return {
     publicKeyCredentialDescriptor,

--- a/src/authenticator/authenticator-emulator.ts
+++ b/src/authenticator/authenticator-emulator.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createPrivateKey, generateKeyPairSync, randomBytes, sign } from "node:crypto";
+import { createCipheriv, createHmac, createPrivateKey, generateKeyPairSync, randomBytes, sign } from "node:crypto";
 import EncodeUtils from "../libs/encode-utils";
 import { PasskeysCredentialsMemoryRepository } from "../repository/credentials-memory-repository";
 import type {
@@ -52,6 +52,14 @@ export type PasskeyCredential = {
   readonly user: PublicKeyCredentialUserEntity | undefined;
 };
 
+export type HmacSecretMode = "none" | "hmac-secret" | "hmac-secret-mc";
+
+type HmacSecretExtension = { "hmac-secret": Uint8Array<ArrayBuffer> | boolean };
+type HmacSecretResult = { credRandom: Uint8Array<ArrayBuffer>; extension: HmacSecretExtension };
+
+const HMAC_SECRET_SALT_LENGTH = 32;
+const CRED_RANDOM_LENGTH = 32;
+
 export type AuthenticatorParameters = {
   readonly aaguid: Uint8Array<ArrayBuffer>;
   readonly transports: AuthenticatorTransport[];
@@ -68,6 +76,7 @@ export type AuthenticatorParameters = {
   ) => InteractionResponse | undefined;
   readonly credentialsRepository: PasskeysCredentialsRepository | undefined;
   readonly stateless: boolean;
+  readonly hmacSecret: HmacSecretMode;
 };
 
 export type MakeCredentialInteraction = (user: PublicKeyCredentialUserEntity, uv: boolean) => boolean;
@@ -95,6 +104,7 @@ export class AuthenticatorEmulator {
 
   private static readonly DEFAULT_CREDENTIALS_REPOSITORY = new PasskeysCredentialsMemoryRepository();
   private static readonly DEFAULT_STATELESS = false;
+  private static readonly DEFAULT_HMAC_SECRET: HmacSecretMode = "none";
   public params: AuthenticatorParameters;
 
   constructor(params: Partial<AuthenticatorParameters> = {}) {
@@ -114,6 +124,7 @@ export class AuthenticatorEmulator {
         ? undefined
         : (params.credentialsRepository ?? AuthenticatorEmulator.DEFAULT_CREDENTIALS_REPOSITORY),
       stateless: params.stateless ?? AuthenticatorEmulator.DEFAULT_STATELESS,
+      hmacSecret: params.hmacSecret ?? AuthenticatorEmulator.DEFAULT_HMAC_SECRET,
     };
   }
 
@@ -296,8 +307,17 @@ export class AuthenticatorEmulator {
 
   /** @see https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorGetInfo */
   public authenticatorGetInfo(): AuthenticatorGetInfoResponse {
+    const extensions: string[] = [];
+    if (this.params.hmacSecret !== "none") {
+      extensions.push("hmac-secret");
+    }
+    if (this.params.hmacSecret === "hmac-secret-mc") {
+      extensions.push("hmac-secret-mc");
+    }
+
     return {
       versions: ["FIDO_2_0"],
+      extensions: extensions.length > 0 ? extensions : undefined,
       aaguid: this.params.aaguid,
       options: {
         rk: true,
@@ -333,6 +353,9 @@ export class AuthenticatorEmulator {
     if (!interactionResponse) throw new AuthenticationEmulatorError(CTAP_STATUS_CODE.CTAP2_ERR_OPERATION_DENIED);
 
     // Create credential
+    const hmacSecret = request.extensions
+      ? makeCredentialHmacSecret(this.params.hmacSecret, request.extensions)
+      : undefined;
     const credential = makeCredential(
       this.params.aaguid,
       rpId,
@@ -341,6 +364,7 @@ export class AuthenticatorEmulator {
       interactionResponse,
       request.user,
       repository ? undefined : AuthenticatorEmulator.ENCRYPT_KEY,
+      hmacSecret,
     );
     if (repository) {
       const discoverableCredential: PasskeyDiscoverableCredential = {
@@ -379,6 +403,13 @@ export class AuthenticatorEmulator {
 
     // Get assertion
     const newSignCount = !repository ? 0 : credential.authenticatorData.signCount + this.params.signCounterIncrement;
+    const extension = request.extensions
+      ? getAssertionHmacSecret(
+          this.params.hmacSecret,
+          request.extensions,
+          credential.publicKeyCredentialSource.credRandom,
+        )
+      : undefined;
     const { authData, signature } = getAssertion(
       rpId.hash,
       request.clientDataHash,
@@ -386,6 +417,7 @@ export class AuthenticatorEmulator {
       credential.publicKeyCredentialSource,
       interactionResponse,
       !repository,
+      extension,
     );
 
     // Update sign count
@@ -418,11 +450,16 @@ function getCredentialsStateless(
 ): PasskeyCredential[] {
   return allowCredentials.map((descriptor) => {
     const id = EncodeUtils.bufferSourceToUint8Array(descriptor.id);
+    const { privateKey, credRandom } = EncodeUtils.decodeCbor<{
+      privateKey: Uint8Array<ArrayBuffer>;
+      credRandom?: Uint8Array<ArrayBuffer>;
+    }>(decryptBytes(key, id));
     const publicKeyCredentialSource: PublicKeyCredentialSource = {
       type: "public-key",
       id,
-      privateKey: decryptBytes(key, id),
+      privateKey,
       rpId: rpId,
+      credRandom,
     };
     const authData: AuthenticatorData = {
       rpIdHash: rpId.hash,
@@ -482,6 +519,7 @@ function getAssertion(
   credential: PublicKeyCredentialSource,
   interactionResponse: InteractionResponse,
   stateless: boolean,
+  extension: HmacSecretExtension | undefined,
 ): { authData: Uint8Array<ArrayBuffer>; signature: Uint8Array<ArrayBuffer> } {
   const authenticatorData = {
     rpIdHash,
@@ -491,9 +529,10 @@ function getAssertion(
       backupEligibility: !stateless,
       backupState: !stateless,
       attestedCredentialData: false,
-      extensionData: false,
+      extensionData: Boolean(extension),
     },
     signCount: newSignCounter,
+    extensions: extension,
   };
 
   const payload: number[] = [];
@@ -512,6 +551,54 @@ function getAssertion(
   return { authData: packAuthenticatorData(authenticatorData), signature };
 }
 
+function computeHmacSecrets(credRandom: Uint8Array<ArrayBuffer>, salts: unknown): Uint8Array<ArrayBuffer> {
+  if (
+    !(salts instanceof Uint8Array) ||
+    (salts.length !== HMAC_SECRET_SALT_LENGTH && salts.length !== 2 * HMAC_SECRET_SALT_LENGTH)
+  ) {
+    throw new AuthenticationEmulatorError(CTAP_STATUS_CODE.CTAP1_ERR_INVALID_PARAMETER);
+  }
+  const outputs = new Uint8Array(salts.length);
+  for (let offset = 0; offset < salts.length; offset += HMAC_SECRET_SALT_LENGTH) {
+    const salt = salts.subarray(offset, offset + HMAC_SECRET_SALT_LENGTH);
+    outputs.set(createHmac("sha256", credRandom).update(salt).digest(), offset);
+  }
+  return outputs;
+}
+
+function makeCredentialHmacSecret(mode: HmacSecretMode, extensions: object): HmacSecretResult | undefined {
+  const requested = extensions as Record<string, unknown>;
+  const enabled = requested["hmac-secret"] === true;
+  const salts = requested["hmac-secret-mc"];
+
+  if (!enabled || mode === "none") {
+    return undefined;
+  }
+
+  const credRandom = new Uint8Array(randomBytes(CRED_RANDOM_LENGTH));
+  if (salts === undefined || mode !== "hmac-secret-mc") {
+    return { credRandom, extension: { "hmac-secret": true } };
+  }
+  return { credRandom, extension: { "hmac-secret": computeHmacSecrets(credRandom, salts) } };
+}
+
+function getAssertionHmacSecret(
+  mode: HmacSecretMode,
+  extensions: object,
+  credRandom: Uint8Array<ArrayBuffer> | undefined,
+): HmacSecretExtension | undefined {
+  const requested = extensions as Record<string, unknown>;
+  const salts = requested["hmac-secret"];
+
+  if (salts === undefined || mode === "none") {
+    return undefined;
+  }
+  if (!credRandom) {
+    return undefined;
+  }
+  return { "hmac-secret": computeHmacSecrets(credRandom, salts) };
+}
+
 function makeCredential(
   aaguid: Uint8Array<ArrayBuffer>,
   rpId: RpId,
@@ -520,6 +607,7 @@ function makeCredential(
   interactionResponse: InteractionResponse,
   user: PublicKeyCredentialUserEntity | undefined,
   statelessKey: Uint8Array<ArrayBuffer> | undefined,
+  hmacSecret: HmacSecretResult | undefined,
 ): PasskeyCredential {
   const generatekeyPair = (alg: keyof typeof COSEAlgorithmIdentifier) => {
     if (alg === "RS256") return generateKeyPairSync("rsa", { modulusLength: 2048 });
@@ -529,7 +617,12 @@ function makeCredential(
 
   const keyPair = generatekeyPair(alg);
   const privateKey = new Uint8Array(keyPair.privateKey.export({ format: "der", type: "pkcs8" }));
-  const credentialId = statelessKey ? encryptBytes(statelessKey, privateKey) : new Uint8Array(randomBytes(32));
+  const credentialId = statelessKey
+    ? encryptBytes(
+        statelessKey,
+        EncodeUtils.encodeCbor(hmacSecret ? { privateKey, credRandom: hmacSecret.credRandom } : { privateKey }),
+      )
+    : new Uint8Array(randomBytes(32));
 
   const publicKeyCredentialSource: PublicKeyCredentialSource = {
     type: "public-key",
@@ -537,6 +630,7 @@ function makeCredential(
     privateKey: new Uint8Array(keyPair.privateKey.export({ format: "der", type: "pkcs8" })),
     rpId: rpId,
     userHandle: user && !statelessKey ? EncodeUtils.bufferSourceToUint8Array(user.id) : undefined,
+    credRandom: hmacSecret?.credRandom,
   };
 
   const publicKeyCredentialDescriptor: PublicKeyCredentialDescriptor = {
@@ -553,7 +647,7 @@ function makeCredential(
       userPresent: interactionResponse.options.up,
       userVerified: interactionResponse.options.uv,
       attestedCredentialData: true,
-      extensionData: false,
+      extensionData: Boolean(hmacSecret),
     },
     signCount: 0,
     attestedCredentialData: {
@@ -561,6 +655,7 @@ function makeCredential(
       credentialId,
       credentialPublicKey: CoseKey.fromKeyObject(keyPair.publicKey),
     },
+    extensions: hmacSecret?.extension,
   };
   return {
     publicKeyCredentialDescriptor,

--- a/src/libs/cbor.ts
+++ b/src/libs/cbor.ts
@@ -107,6 +107,11 @@ class CborReader {
     return value;
   }
 
+  readWithRemainder(): { value: unknown; remainder: Uint8Array<ArrayBuffer> } {
+    const value = this.readValue();
+    return { value, remainder: this.data.slice(this.offset) };
+  }
+
   private readValue(): unknown {
     const initialByte = this.readByte();
     const majorType = initialByte >> 5;
@@ -214,4 +219,12 @@ class CborReader {
 
 export function decodeCbor<T>(data: Uint8Array<ArrayBuffer>): T {
   return new CborReader(data).read() as T;
+}
+
+export function decodeCborWithRemainder<T>(data: Uint8Array<ArrayBuffer>): {
+  value: T;
+  remainder: Uint8Array<ArrayBuffer>;
+} {
+  const { value, remainder } = new CborReader(data).readWithRemainder();
+  return { value: value as T, remainder };
 }

--- a/src/libs/encode-utils.ts
+++ b/src/libs/encode-utils.ts
@@ -1,4 +1,4 @@
-import { decodeCbor, encodeCbor } from "./cbor";
+import { decodeCbor, decodeCborWithRemainder, encodeCbor } from "./cbor";
 
 function encodeBase64Url(data: BufferSource): string {
   const buffer = bufferSourceToUint8Array(data);
@@ -36,5 +36,6 @@ const EncodeUtils = {
   decodeBase64Url,
   encodeCbor,
   decodeCbor,
+  decodeCborWithRemainder,
 };
 export default EncodeUtils;

--- a/src/webauthn/cose-key.ts
+++ b/src/webauthn/cose-key.ts
@@ -33,14 +33,17 @@ export abstract class CoseKey {
   }
 
   public static fromBytes(bytes: Uint8Array<ArrayBuffer>): CoseKey {
-    const coseKey = EncodeUtils.decodeCbor<Record<number, unknown>>(bytes);
+    return CoseKey.fromDecoded(EncodeUtils.decodeCbor<Record<number, unknown>>(bytes));
+  }
+
+  public static fromDecoded(coseKey: Record<number, unknown>): CoseKey {
     switch (coseKey[3]) {
       case -7:
-        return CoseKeyP256.fromBytes(bytes);
+        return new CoseKeyP256(coseKey[-2] as Uint8Array<ArrayBuffer>, coseKey[-3] as Uint8Array<ArrayBuffer>);
       case -8:
-        return CoseKeyEd25519.fromBytes(bytes);
+        return new CoseKeyEd25519(coseKey[-2] as Uint8Array<ArrayBuffer>);
       case -257:
-        return CoseKeyRSA.fromBytes(bytes);
+        return new CoseKeyRSA(coseKey[-1] as Uint8Array<ArrayBuffer>, coseKey[-2] as Uint8Array<ArrayBuffer>);
       default:
         throw new Error("Not supported key type");
     }
@@ -82,11 +85,6 @@ class CoseKeyP256 extends CoseKey {
     };
   }
 
-  public static fromBytes(bytes: Uint8Array<ArrayBuffer>): CoseKeyP256 {
-    const coseKey = EncodeUtils.decodeCbor<Record<number, unknown>>(bytes);
-    return new CoseKeyP256(coseKey[-2] as Uint8Array<ArrayBuffer>, coseKey[-3] as Uint8Array<ArrayBuffer>);
-  }
-
   public static fromJwk(jwk: JsonWebKey): CoseKeyP256 {
     return new CoseKeyP256(EncodeUtils.decodeBase64Url(jwk.x as string), EncodeUtils.decodeBase64Url(jwk.y as string));
   }
@@ -113,11 +111,6 @@ class CoseKeyEd25519 extends CoseKey {
       crv: "Ed25519",
       x: EncodeUtils.encodeBase64Url(this.x),
     };
-  }
-
-  public static fromBytes(bytes: Uint8Array<ArrayBuffer>): CoseKeyEd25519 {
-    const coseKey = EncodeUtils.decodeCbor<Record<number, unknown>>(bytes);
-    return new CoseKeyEd25519(coseKey[-2] as Uint8Array<ArrayBuffer>);
   }
 
   public static fromJwk(jwk: JsonWebKey): CoseKeyEd25519 {
@@ -149,11 +142,6 @@ class CoseKeyRSA extends CoseKey {
       n: EncodeUtils.encodeBase64Url(this.n),
       e: EncodeUtils.encodeBase64Url(this.e),
     };
-  }
-
-  public static fromBytes(bytes: Uint8Array<ArrayBuffer>): CoseKeyRSA {
-    const coseKey = EncodeUtils.decodeCbor<Record<number, unknown>>(bytes);
-    return new CoseKeyRSA(coseKey[-1] as Uint8Array<ArrayBuffer>, coseKey[-2] as Uint8Array<ArrayBuffer>);
   }
 
   public static fromJwk(jwk: JsonWebKey): CoseKeyRSA {

--- a/src/webauthn/webauthn-emulator.ts
+++ b/src/webauthn/webauthn-emulator.ts
@@ -272,7 +272,9 @@ export class WebAuthnEmulator {
         throw new DOMException("prf.evalByCredential requires allowCredentials", "NotSupportedError");
       }
       let prfValues = prf.eval;
-      // We currently resolve evalByCredential only for a single requested credential.
+      // In real browsers the WebAuthn layer selects the credential before building the CTAP request, which
+      // resolves evalByCredential to that credential's salt. The NID emulator selects credentials in the
+      // CTAP layer, so we only handle a single allowed credential to avoid polluting the CTAP layer
       if (prf.evalByCredential && allowCredentials?.length === 1) {
         const credentialId = EncodeUtils.encodeBase64Url(allowCredentials[0].id);
         prfValues = prf.evalByCredential[credentialId] ?? prfValues;

--- a/src/webauthn/webauthn-emulator.ts
+++ b/src/webauthn/webauthn-emulator.ts
@@ -265,7 +265,7 @@ export class WebAuthnEmulator {
     };
 
     const prf = options.publicKey.extensions?.prf;
-    let requestExtensions: object | undefined;
+    const requestExtensions: Record<string, unknown> = {};
     if (prf && (prf.eval || prf.evalByCredential)) {
       const allowCredentials = options.publicKey.allowCredentials;
       if (prf.evalByCredential && !allowCredentials?.length) {
@@ -278,7 +278,7 @@ export class WebAuthnEmulator {
         prfValues = prf.evalByCredential[credentialId] ?? prfValues;
       }
       if (prfValues) {
-        requestExtensions = { "hmac-secret": prfValuesToSalts(prfValues) };
+        requestExtensions["hmac-secret"] = prfValuesToSalts(prfValues);
       }
     }
 
@@ -352,11 +352,12 @@ export class WebAuthnEmulator {
     const clientDataJSON = JSON.stringify(clientData);
 
     const prf = options.publicKey.extensions?.prf;
-    let requestExtensions: object | undefined;
+    const requestExtensions: Record<string, unknown> = {};
     if (prf) {
-      requestExtensions = prf.eval
-        ? { "hmac-secret": true, "hmac-secret-mc": prfValuesToSalts(prf.eval) }
-        : { "hmac-secret": true };
+      requestExtensions["hmac-secret"] = true;
+      if (prf.eval) {
+        requestExtensions["hmac-secret-mc"] = prfValuesToSalts(prf.eval);
+      }
     }
 
     const authenticatorRequest = packMakeCredentialRequest({

--- a/src/webauthn/webauthn-emulator.ts
+++ b/src/webauthn/webauthn-emulator.ts
@@ -44,6 +44,9 @@ export type AuthenticatorInfo = {
   };
 };
 
+const PRF_OUTPUT_LENGTH = 32;
+const PRF_SALT_PREFIX = EncodeUtils.strToUint8Array("WebAuthn PRF");
+
 export class WebAuthnEmulatorError extends Error {}
 
 /**
@@ -261,12 +264,31 @@ export class WebAuthnEmulator {
       crossOrigin: false,
     };
 
+    const prf = options.publicKey.extensions?.prf;
+    let requestExtensions: object | undefined;
+    if (prf && (prf.eval || prf.evalByCredential)) {
+      const allowCredentials = options.publicKey.allowCredentials;
+      if (prf.evalByCredential && !allowCredentials?.length) {
+        throw new DOMException("prf.evalByCredential requires allowCredentials", "NotSupportedError");
+      }
+      let prfValues = prf.eval;
+      // We currently resolve evalByCredential only for a single requested credential.
+      if (prf.evalByCredential && allowCredentials?.length === 1) {
+        const credentialId = EncodeUtils.encodeBase64Url(allowCredentials[0].id);
+        prfValues = prf.evalByCredential[credentialId] ?? prfValues;
+      }
+      if (prfValues) {
+        requestExtensions = { "hmac-secret": prfValuesToSalts(prfValues) };
+      }
+    }
+
     const authenticatorRequest = packGetAssertionRequest({
       rpId: rpId.value,
       clientDataHash: EncodeUtils.bufferSourceToUint8Array(
         new Uint8Array(createHash("sha256").update(JSON.stringify(clientData)).digest()),
       ),
       allowList: options.publicKey.allowCredentials,
+      extensions: requestExtensions,
       options: toFido2RequestOptions(options.publicKey.userVerification),
     });
     const authenticatorResponse = this.handleAuthenticatorCall(() =>
@@ -285,14 +307,24 @@ export class WebAuthnEmulator {
       rawId: rawId.buffer,
       response: {
         clientDataJSON: EncodeUtils.strToUint8Array(JSON.stringify(clientData)).buffer,
-        authenticatorData: packAuthenticatorData(authData).buffer,
+        authenticatorData: authenticatorResponse.authData.buffer,
         signature: authenticatorResponse.signature.buffer,
         userHandle: authenticatorResponse.user
           ? EncodeUtils.bufferSourceToUint8Array(authenticatorResponse.user.id).buffer
           : null,
       },
       authenticatorAttachment: null,
-      getClientExtensionResults: () => ({ credProps: { rk: authenticatorResponse.user !== undefined } }),
+      getClientExtensionResults: () => {
+        const results: AuthenticationExtensionsClientOutputs = {
+          credProps: { rk: authenticatorResponse.user !== undefined },
+        };
+        const extensions = authData.extensions as { "hmac-secret"?: Uint8Array<ArrayBuffer> | boolean } | undefined;
+        const hmacOutput = extensions?.["hmac-secret"];
+        if (hmacOutput instanceof Uint8Array) {
+          results.prf = { results: hmacSecretToPrfResults(hmacOutput) };
+        }
+        return results;
+      },
       toJSON: () => toAuthenticationResponseJSON(publicKeyCredential),
     };
 
@@ -319,6 +351,14 @@ export class WebAuthnEmulator {
     };
     const clientDataJSON = JSON.stringify(clientData);
 
+    const prf = options.publicKey.extensions?.prf;
+    let requestExtensions: object | undefined;
+    if (prf) {
+      requestExtensions = prf.eval
+        ? { "hmac-secret": true, "hmac-secret-mc": prfValuesToSalts(prf.eval) }
+        : { "hmac-secret": true };
+    }
+
     const authenticatorRequest = packMakeCredentialRequest({
       clientDataHash: EncodeUtils.bufferSourceToUint8Array(
         new Uint8Array(createHash("sha256").update(clientDataJSON).digest()),
@@ -327,6 +367,7 @@ export class WebAuthnEmulator {
       user: options.publicKey.user,
       pubKeyCredParams: options.publicKey.pubKeyCredParams,
       excludeList: options.publicKey.excludeCredentials,
+      extensions: requestExtensions,
       options: toFido2CreateOptions(options.publicKey.authenticatorSelection),
     });
     const authenticatorResponse = this.handleAuthenticatorCall(() =>
@@ -358,10 +399,57 @@ export class WebAuthnEmulator {
       rawId: attestedCredentialData.credentialId.buffer,
       response,
       authenticatorAttachment: null,
-      getClientExtensionResults: () => ({ credProps: { rk: true } }),
+      getClientExtensionResults: () => {
+        const results: AuthenticationExtensionsClientOutputs = { credProps: { rk: true } };
+        if (prf) {
+          const extensions = authData.extensions as { "hmac-secret"?: Uint8Array<ArrayBuffer> | boolean } | undefined;
+          const hmacOutput = extensions?.["hmac-secret"];
+          if (hmacOutput instanceof Uint8Array) {
+            results.prf = { enabled: true, results: hmacSecretToPrfResults(hmacOutput) };
+          } else {
+            results.prf = { enabled: hmacOutput === true };
+          }
+        }
+        return results;
+      },
       toJSON: () => toRegistrationResponseJSON(publicKeyCredential),
     };
 
     return publicKeyCredential;
   }
+}
+
+// A PRF input maps to a CTAP hmac-secret salt as SHA-256("WebAuthn PRF" || 0x00 || input).
+function prfInputToSalt(input: BufferSource): Uint8Array<ArrayBuffer> {
+  const inputBytes = EncodeUtils.bufferSourceToUint8Array(input);
+  if (inputBytes.length === 0) {
+    throw new TypeError("PRF eval input must not be empty");
+  }
+  const data = new Uint8Array(PRF_SALT_PREFIX.length + 1 + inputBytes.length);
+  data.set(PRF_SALT_PREFIX, 0);
+  data.set(inputBytes, PRF_SALT_PREFIX.length + 1);
+  return new Uint8Array(createHash("sha256").update(data).digest());
+}
+
+function prfValuesToSalts(values: AuthenticationExtensionsPRFValues): Uint8Array<ArrayBuffer> {
+  const first = prfInputToSalt(values.first);
+  let salts = first;
+
+  if (values.second) {
+    const second = prfInputToSalt(values.second);
+    salts = new Uint8Array(first.length + second.length);
+    salts.set(first, 0);
+    salts.set(second, first.length);
+  }
+  return salts;
+}
+
+function hmacSecretToPrfResults(output: Uint8Array<ArrayBuffer>): AuthenticationExtensionsPRFValues {
+  if (output.length === PRF_OUTPUT_LENGTH) {
+    return { first: output.slice(0, PRF_OUTPUT_LENGTH).buffer };
+  }
+  return {
+    first: output.slice(0, PRF_OUTPUT_LENGTH).buffer,
+    second: output.slice(PRF_OUTPUT_LENGTH, 2 * PRF_OUTPUT_LENGTH).buffer,
+  };
 }

--- a/src/webauthn/webauthn-emulator.ts
+++ b/src/webauthn/webauthn-emulator.ts
@@ -266,10 +266,22 @@ export class WebAuthnEmulator {
 
     const prf = options.publicKey.extensions?.prf;
     const requestExtensions: Record<string, unknown> = {};
-    if (prf && (prf.eval || prf.evalByCredential)) {
+    if (prf) {
       const allowCredentials = options.publicKey.allowCredentials;
-      if (prf.evalByCredential && !allowCredentials?.length) {
-        throw new DOMException("prf.evalByCredential requires allowCredentials", "NotSupportedError");
+      const evalByCredentialKeys = prf.evalByCredential ? Object.keys(prf.evalByCredential) : [];
+      if (evalByCredentialKeys.length > 0) {
+        if (!allowCredentials?.length) {
+          throw new DOMException("prf.evalByCredential requires allowCredentials", "NotSupportedError");
+        }
+        const allowedIds = new Set(allowCredentials.map((credential) => EncodeUtils.encodeBase64Url(credential.id)));
+        for (const key of evalByCredentialKeys) {
+          if (!allowedIds.has(key)) {
+            throw new DOMException(
+              "prf.evalByCredential contains a credential id not in allowCredentials",
+              "SyntaxError",
+            );
+          }
+        }
       }
       let prfValues = prf.eval;
       // In real browsers the WebAuthn layer selects the credential before building the CTAP request, which
@@ -354,6 +366,9 @@ export class WebAuthnEmulator {
     const clientDataJSON = JSON.stringify(clientData);
 
     const prf = options.publicKey.extensions?.prf;
+    if (prf?.evalByCredential !== undefined) {
+      throw new DOMException("prf.evalByCredential is not supported during credential creation", "NotSupportedError");
+    }
     const requestExtensions: Record<string, unknown> = {};
     if (prf) {
       requestExtensions["hmac-secret"] = true;

--- a/src/webauthn/webauthn-model-json.ts
+++ b/src/webauthn/webauthn-model-json.ts
@@ -13,7 +13,7 @@ export function parseCreationOptionsFromJSON(
     excludeCredentials: optionsJSON.excludeCredentials?.map(parsePublicKeyCredentialDescriptorFromJSON),
     authenticatorSelection: optionsJSON.authenticatorSelection,
     attestation: optionsJSON.attestation as AttestationConveyancePreference,
-    extensions: optionsJSON.extensions as AuthenticationExtensionsClientInputs | undefined,
+    extensions: parseExtensionsFromJSON(optionsJSON.extensions),
   };
 }
 
@@ -27,7 +27,7 @@ export function parseRequestOptionsFromJSON(
     rpId: optionsJSON.rpId,
     allowCredentials: optionsJSON.allowCredentials?.map(parsePublicKeyCredentialDescriptorFromJSON),
     userVerification: optionsJSON.userVerification as UserVerificationRequirement,
-    extensions: optionsJSON.extensions as AuthenticationExtensionsClientInputs | undefined,
+    extensions: parseExtensionsFromJSON(optionsJSON.extensions),
   };
 }
 
@@ -70,7 +70,7 @@ export function toRegistrationResponseJSON(credential: PublicKeyCredential): Reg
       credential.authenticatorAttachment === null
         ? undefined
         : (credential.authenticatorAttachment as AuthenticatorAttachment),
-    clientExtensionResults: credential.getClientExtensionResults() as AuthenticationExtensionsClientOutputsJSON,
+    clientExtensionResults: toExtensionResultsJSON(credential.getClientExtensionResults()),
     type: credential.type as PublicKeyCredentialType,
   };
 }
@@ -91,7 +91,7 @@ export function toAuthenticationResponseJSON(credential: PublicKeyCredential): A
       credential.authenticatorAttachment === null
         ? undefined
         : (credential.authenticatorAttachment as AuthenticatorAttachment),
-    clientExtensionResults: credential.getClientExtensionResults() as AuthenticationExtensionsClientOutputsJSON,
+    clientExtensionResults: toExtensionResultsJSON(credential.getClientExtensionResults()),
     type: credential.type as PublicKeyCredentialType,
   };
 }
@@ -191,6 +191,64 @@ export function parsePublicKeyCredentialUserEntityFromJSON(
   user: PublicKeyCredentialUserEntityJSON,
 ): PublicKeyCredentialUserEntity {
   return { ...user, id: decodeBase64Url(user.id) };
+}
+
+function parsePRFValuesFromJSON(values: AuthenticationExtensionsPRFValuesJSON): AuthenticationExtensionsPRFValues {
+  const parsed: AuthenticationExtensionsPRFValues = { first: decodeBase64Url(values.first) };
+  if (values.second !== undefined) {
+    parsed.second = decodeBase64Url(values.second);
+  }
+  return parsed;
+}
+
+function parsePRFInputsFromJSON(prf: AuthenticationExtensionsPRFInputsJSON): AuthenticationExtensionsPRFInputs {
+  const parsed: AuthenticationExtensionsPRFInputs = {};
+  if (prf.eval) {
+    parsed.eval = parsePRFValuesFromJSON(prf.eval);
+  }
+  if (prf.evalByCredential) {
+    parsed.evalByCredential = Object.fromEntries(
+      Object.entries(prf.evalByCredential).map(
+        ([credentialId, values]) => [credentialId, parsePRFValuesFromJSON(values)] as const,
+      ),
+    );
+  }
+  return parsed;
+}
+
+// Decodes each supported extension's JSON-encoded inputs into their non-json form.
+// Only prf is decoding today, future extension with encoded inputs should add code here
+function parseExtensionsFromJSON(
+  extensionsJSON: AuthenticationExtensionsClientInputsJSON | undefined,
+): AuthenticationExtensionsClientInputs | undefined {
+  if (!extensionsJSON) {
+    return undefined;
+  }
+  const parsed = { ...extensionsJSON } as AuthenticationExtensionsClientInputs;
+  if (extensionsJSON.prf) {
+    parsed.prf = parsePRFInputsFromJSON(extensionsJSON.prf);
+  }
+  return parsed;
+}
+
+function toPRFValuesJSON(values: AuthenticationExtensionsPRFValues): AuthenticationExtensionsPRFValuesJSON {
+  const json: AuthenticationExtensionsPRFValuesJSON = { first: encodeBase64Url(values.first) };
+  if (values.second !== undefined) {
+    json.second = encodeBase64Url(values.second);
+  }
+  return json;
+}
+
+// Encodes each supported extension's outputs into their json form.
+// Only prf is encoding today, future extension with encoded outputs should add code here
+function toExtensionResultsJSON(
+  results: AuthenticationExtensionsClientOutputs,
+): AuthenticationExtensionsClientOutputsJSON {
+  const json = { ...results } as AuthenticationExtensionsClientOutputsJSON;
+  if (results.prf?.results) {
+    json.prf = { ...results.prf, results: toPRFValuesJSON(results.prf.results) };
+  }
+  return json;
 }
 
 // Helper functions

--- a/src/webauthn/webauthn-model-json.ts
+++ b/src/webauthn/webauthn-model-json.ts
@@ -217,7 +217,7 @@ function parsePRFInputsFromJSON(prf: AuthenticationExtensionsPRFInputsJSON): Aut
 }
 
 // Decodes each supported extension's JSON-encoded inputs into their non-json form.
-// Only prf is decoding today, future extension with encoded inputs should add code here
+// Only prf needs decoding today; a future extension with encoded inputs should add code here.
 function parseExtensionsFromJSON(
   extensionsJSON: AuthenticationExtensionsClientInputsJSON | undefined,
 ): AuthenticationExtensionsClientInputs | undefined {
@@ -240,7 +240,7 @@ function toPRFValuesJSON(values: AuthenticationExtensionsPRFValues): Authenticat
 }
 
 // Encodes each supported extension's outputs into their json form.
-// Only prf is encoding today, future extension with encoded outputs should add code here
+// Only prf needs encoding today; a future extension with encoded outputs should add code here.
 function toExtensionResultsJSON(
   results: AuthenticationExtensionsClientOutputs,
 ): AuthenticationExtensionsClientOutputsJSON {

--- a/src/webauthn/webauthn-model-json.ts
+++ b/src/webauthn/webauthn-model-json.ts
@@ -108,7 +108,7 @@ export function toCreationOptionsJSON(
     excludeCredentials: options.excludeCredentials?.map(toPublicKeyCredentialDescriptorJSON),
     authenticatorSelection: options.authenticatorSelection,
     attestation: options.attestation,
-    extensions: options.extensions as AuthenticationExtensionsClientInputsJSON | undefined,
+    extensions: toExtensionInputsJSON(options.extensions),
   };
 }
 
@@ -121,7 +121,7 @@ export function toRequestOptionsJSON(
     rpId: options.rpId,
     allowCredentials: options.allowCredentials?.map(toPublicKeyCredentialDescriptorJSON),
     userVerification: options.userVerification,
-    extensions: options.extensions as AuthenticationExtensionsClientInputsJSON | undefined,
+    extensions: toExtensionInputsJSON(options.extensions),
   };
 }
 
@@ -138,7 +138,7 @@ export function parseRegistrationResponseFromJSON(options: RegistrationResponseJ
       attestationObject: decodeBase64Url(options.response.attestationObject),
     },
     authenticatorAttachment: options.authenticatorAttachment ?? null,
-    getClientExtensionResults: () => options.clientExtensionResults as AuthenticationExtensionsClientOutputs,
+    getClientExtensionResults: () => parseExtensionResultsFromJSON(options.clientExtensionResults),
     toJSON: () => options,
     type: options.type,
   };
@@ -155,7 +155,7 @@ export function parseAuthenticationResponseFromJSON(options: AuthenticationRespo
       userHandle: options.response.userHandle ? decodeBase64Url(options.response.userHandle) : null,
     },
     authenticatorAttachment: options.authenticatorAttachment ?? null,
-    getClientExtensionResults: () => options.clientExtensionResults as AuthenticationExtensionsClientOutputs,
+    getClientExtensionResults: () => parseExtensionResultsFromJSON(options.clientExtensionResults),
     toJSON: () => options,
     type: options.type,
   };
@@ -193,7 +193,9 @@ export function parsePublicKeyCredentialUserEntityFromJSON(
   return { ...user, id: decodeBase64Url(user.id) };
 }
 
-function parsePRFValuesFromJSON(values: AuthenticationExtensionsPRFValuesJSON): AuthenticationExtensionsPRFValues {
+export function parsePRFValuesFromJSON(
+  values: AuthenticationExtensionsPRFValuesJSON,
+): AuthenticationExtensionsPRFValues {
   const parsed: AuthenticationExtensionsPRFValues = { first: decodeBase64Url(values.first) };
   if (values.second !== undefined) {
     parsed.second = decodeBase64Url(values.second);
@@ -217,7 +219,7 @@ function parsePRFInputsFromJSON(prf: AuthenticationExtensionsPRFInputsJSON): Aut
 }
 
 // Decodes each supported extension's JSON-encoded inputs into their non-json form.
-// Only prf needs decoding today; a future extension with encoded inputs should add code here.
+// Only prf needs decoding today. A future extension with encoded inputs should add code here.
 function parseExtensionsFromJSON(
   extensionsJSON: AuthenticationExtensionsClientInputsJSON | undefined,
 ): AuthenticationExtensionsClientInputs | undefined {
@@ -231,7 +233,19 @@ function parseExtensionsFromJSON(
   return parsed;
 }
 
-function toPRFValuesJSON(values: AuthenticationExtensionsPRFValues): AuthenticationExtensionsPRFValuesJSON {
+// Decodes each supported extension's JSON-encoded outputs into their non-json form.
+// Only prf needs decoding today. A future extension with encoded outputs should add code here.
+export function parseExtensionResultsFromJSON(
+  resultsJSON: AuthenticationExtensionsClientOutputsJSON,
+): AuthenticationExtensionsClientOutputs {
+  const parsed = { ...resultsJSON } as AuthenticationExtensionsClientOutputs;
+  if (resultsJSON.prf?.results) {
+    parsed.prf = { ...resultsJSON.prf, results: parsePRFValuesFromJSON(resultsJSON.prf.results) };
+  }
+  return parsed;
+}
+
+export function toPRFValuesJSON(values: AuthenticationExtensionsPRFValues): AuthenticationExtensionsPRFValuesJSON {
   const json: AuthenticationExtensionsPRFValuesJSON = { first: encodeBase64Url(values.first) };
   if (values.second !== undefined) {
     json.second = encodeBase64Url(values.second);
@@ -240,13 +254,43 @@ function toPRFValuesJSON(values: AuthenticationExtensionsPRFValues): Authenticat
 }
 
 // Encodes each supported extension's outputs into their json form.
-// Only prf needs encoding today; a future extension with encoded outputs should add code here.
+// Only prf needs encoding today. A future extension with encoded outputs should add code here.
 function toExtensionResultsJSON(
   results: AuthenticationExtensionsClientOutputs,
 ): AuthenticationExtensionsClientOutputsJSON {
   const json = { ...results } as AuthenticationExtensionsClientOutputsJSON;
   if (results.prf?.results) {
     json.prf = { ...results.prf, results: toPRFValuesJSON(results.prf.results) };
+  }
+  return json;
+}
+
+export function toPRFInputsJSON(prf: AuthenticationExtensionsPRFInputs): AuthenticationExtensionsPRFInputsJSON {
+  const json: AuthenticationExtensionsPRFInputsJSON = {};
+  if (prf.eval) {
+    json.eval = toPRFValuesJSON(prf.eval);
+  }
+  if (prf.evalByCredential) {
+    json.evalByCredential = Object.fromEntries(
+      Object.entries(prf.evalByCredential).map(
+        ([credentialId, values]) => [credentialId, toPRFValuesJSON(values)] as const,
+      ),
+    );
+  }
+  return json;
+}
+
+// Encodes each supported extension's inputs into their json form.
+// Only prf needs encoding today. A future extension with encoded inputs should add code here.
+export function toExtensionInputsJSON(
+  extensions: AuthenticationExtensionsClientInputs | undefined,
+): AuthenticationExtensionsClientInputsJSON | undefined {
+  if (!extensions) {
+    return undefined;
+  }
+  const json = { ...extensions } as AuthenticationExtensionsClientInputsJSON;
+  if (extensions.prf) {
+    json.prf = toPRFInputsJSON(extensions.prf);
   }
   return json;
 }

--- a/src/webauthn/webauthn-model.ts
+++ b/src/webauthn/webauthn-model.ts
@@ -98,10 +98,18 @@ export function packAttestationObject(attestationObject: AttestationObject): Uin
 export function packAuthenticatorData(authData: AuthenticatorData): Uint8Array<ArrayBuffer> {
   const ret: Array<number> = [];
   const cred = authData.attestedCredentialData;
+  const extensions = authData.extensions;
   ret.push(...authData.rpIdHash);
-  ret.push(packAuthenticatorDataFlags({ ...authData.flags, attestedCredentialData: Boolean(cred) }));
+  ret.push(
+    packAuthenticatorDataFlags({
+      ...authData.flags,
+      attestedCredentialData: Boolean(cred),
+      extensionData: Boolean(extensions),
+    }),
+  );
   ret.push(...packSignCount(authData.signCount));
   if (cred) ret.push(...packAttestedCredentialData(cred));
+  if (extensions) ret.push(...EncodeUtils.encodeCbor(extensions));
   return new Uint8Array(ret);
 }
 
@@ -152,18 +160,38 @@ export function unpackAuthenticatorData(authData: Uint8Array<ArrayBuffer>): Auth
   const rpIdHash = authData.slice(0, 32);
   const flags = unpackAuthenticatorDataFlags(authData[32]);
   const signCount = (authData[33] << 24) | (authData[34] << 16) | (authData[35] << 8) | authData[36];
-  const attestedCredentialData = flags.attestedCredentialData
-    ? unpackAttestedCredentialData(authData.slice(37))
-    : undefined;
-  return { rpIdHash, flags, signCount, attestedCredentialData };
+
+  let offset = 37;
+  let attestedCredentialData: AttestedCredentialData | undefined;
+  if (flags.attestedCredentialData) {
+    const unpacked = unpackAttestedCredentialData(authData.slice(offset));
+    attestedCredentialData = unpacked.attestedCredentialData;
+    offset += unpacked.length;
+  }
+
+  let extensions: object | undefined;
+  if (flags.extensionData) {
+    extensions = EncodeUtils.decodeCbor(authData.slice(offset));
+  }
+
+  return { rpIdHash, flags, signCount, attestedCredentialData, extensions };
 }
 
-function unpackAttestedCredentialData(data: Uint8Array<ArrayBuffer>): AttestedCredentialData {
+function unpackAttestedCredentialData(data: Uint8Array<ArrayBuffer>): {
+  attestedCredentialData: AttestedCredentialData;
+  length: number;
+} {
   const aaguid = data.slice(0, 16);
   const credentialIdLength = (data[16] << 8) | data[17];
   const credentialId = data.slice(18, 18 + credentialIdLength);
-  const publicKey = CoseKey.fromBytes(data.slice(18 + credentialIdLength));
-  return { aaguid, credentialId, credentialPublicKey: publicKey };
+  const { value, remainder } = EncodeUtils.decodeCborWithRemainder<Record<number, unknown>>(
+    data.slice(18 + credentialIdLength),
+  );
+  const credentialPublicKey = CoseKey.fromDecoded(value);
+  return {
+    attestedCredentialData: { aaguid, credentialId, credentialPublicKey },
+    length: data.length - remainder.length,
+  };
 }
 
 function unpackAuthenticatorDataFlags(flags: number): AuthenticatorData["flags"] {

--- a/src/webauthn/webauthn-model.ts
+++ b/src/webauthn/webauthn-model.ts
@@ -98,7 +98,8 @@ export function packAttestationObject(attestationObject: AttestationObject): Uin
 export function packAuthenticatorData(authData: AuthenticatorData): Uint8Array<ArrayBuffer> {
   const ret: Array<number> = [];
   const cred = authData.attestedCredentialData;
-  const extensions = authData.extensions;
+  const extensions =
+    authData.extensions && Object.keys(authData.extensions).length > 0 ? authData.extensions : undefined;
   ret.push(...authData.rpIdHash);
   ret.push(
     packAuthenticatorDataFlags({

--- a/src/webauthn/webauthn-model.ts
+++ b/src/webauthn/webauthn-model.ts
@@ -45,6 +45,8 @@ export type PublicKeyCredentialSource = {
   privateKey: Uint8Array<ArrayBuffer>;
   rpId: RpId;
   userHandle?: Uint8Array<ArrayBuffer>;
+  // Per-credential 32 byte secret for PRF extension (CTAP2 hmac-secret)
+  credRandom?: Uint8Array<ArrayBuffer>;
 };
 
 /** @see https://www.w3.org/TR/webauthn-3/#sctn-attested-credential-data */
@@ -181,6 +183,7 @@ export type PublicKeyCredentialSourceJSON = {
   privateKey: string;
   rpId: string;
   userHandle?: string;
+  credRandom?: string;
 };
 
 export function toPublickeyCredentialSourceJSON(
@@ -192,6 +195,7 @@ export function toPublickeyCredentialSourceJSON(
     privateKey: EncodeUtils.encodeBase64Url(credentialSource.privateKey),
     rpId: credentialSource.rpId.value,
     userHandle: credentialSource.userHandle ? EncodeUtils.encodeBase64Url(credentialSource.userHandle) : undefined,
+    credRandom: credentialSource.credRandom ? EncodeUtils.encodeBase64Url(credentialSource.credRandom) : undefined,
   };
 }
 
@@ -202,6 +206,7 @@ export function parsePublicKeyCredentialSourceFromJSON(json: PublicKeyCredential
     privateKey: EncodeUtils.decodeBase64Url(json.privateKey),
     rpId: new RpId(json.rpId),
     userHandle: json.userHandle ? EncodeUtils.decodeBase64Url(json.userHandle) : undefined,
+    credRandom: json.credRandom ? EncodeUtils.decodeBase64Url(json.credRandom) : undefined,
   };
 }
 


### PR DESCRIPTION
  ## Summary

Nikkei/nid-webauthn-emulator#316 Add WebAuthn PRF / CTAP2 `hmac-secret` and CTAP 2.2 `hmac-secret-mc` extensions.

  ## AuthenticatorEmulator

-  A new `hmacSecret` parameter sets the CTAP hmac-secret mode to either "none", "hmac-secret", or "hmac-secret-mc" (defaults to "none")
-  see updated docs for details

  ## WebAuthnEmulator

-  `create`/`get` (and `createJSON`/`getJSON`) map the WebAuthn prf extension to CTAP `hmac-secret` or `hmac-secret-mc`
-  see updated docs for details

  ## Notes

-  I made extension handling somewhat generalized (without over complicating) so future extension can be added
-  Internal credential bound `credRandom` round-trips through credential JSON store and the id blob in stateless mode for consistent credential-salt key outputs
-  In stateless mode, the internal credential d blob schema changed to CBOR `{privateKey, credRandom?}`. I assume stateless ids are meant to be ephemeral / per-process so that schema changes are allowed
-  New unit tests at the authenticator and WebAuthn levels
-  "Real world" integration testing done with my own [Quick Crypt server API tests](https://github.com/bschick/qcrypt/tree/prf-phase3)
-  I only updated english docs. Need help updating Japanese versions

