### PR TITLE
made deleteCredential unlink synchronous to remove race

### DIFF
--- a/spec/repository/credential-repository.spec.ts
+++ b/spec/repository/credential-repository.spec.ts
@@ -83,4 +83,25 @@ describe("Credential Repository Test", () => {
       fs.rmSync(TEST_CREDENTIALS_DIR, { recursive: true, force: true });
     }
   });
+
+  test("File Repository save after delete race", async () => {
+    const deserialized = deserializeCredential(JSON.stringify(testCredentialJSON));
+    const TEST_CREDENTIALS_DIR = path.join(__dirname, "test-credentials-resave");
+    try {
+      fs.rmSync(TEST_CREDENTIALS_DIR, { recursive: true, force: true });
+      const repository = new PasskeysCredentialsFileRepository(TEST_CREDENTIALS_DIR);
+
+      // Validates that a delete does not clobber a follow-on write
+      repository.saveCredential(deserialized);
+      repository.deleteCredential(deserialized);
+      repository.saveCredential(deserialized);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const loaded = repository.loadCredentials();
+      assert.deepEqual(loaded.length, 1);
+      assert.deepEqual(loaded[0], deserialized);
+    } finally {
+      fs.rmSync(TEST_CREDENTIALS_DIR, { recursive: true, force: true });
+    }
+  });
 });

--- a/spec/repository/credential-repository.spec.ts
+++ b/spec/repository/credential-repository.spec.ts
@@ -83,25 +83,4 @@ describe("Credential Repository Test", () => {
       fs.rmSync(TEST_CREDENTIALS_DIR, { recursive: true, force: true });
     }
   });
-
-  test("File Repository save after delete race", async () => {
-    const deserialized = deserializeCredential(JSON.stringify(testCredentialJSON));
-    const TEST_CREDENTIALS_DIR = path.join(__dirname, "test-credentials-resave");
-    try {
-      fs.rmSync(TEST_CREDENTIALS_DIR, { recursive: true, force: true });
-      const repository = new PasskeysCredentialsFileRepository(TEST_CREDENTIALS_DIR);
-
-      // Validates that a delete does not clobber a follow-on write
-      repository.saveCredential(deserialized);
-      repository.deleteCredential(deserialized);
-      repository.saveCredential(deserialized);
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      const loaded = repository.loadCredentials();
-      assert.deepEqual(loaded.length, 1);
-      assert.deepEqual(loaded[0], deserialized);
-    } finally {
-      fs.rmSync(TEST_CREDENTIALS_DIR, { recursive: true, force: true });
-    }
-  });
 });

--- a/src/repository/credentials-file-repository.ts
+++ b/src/repository/credentials-file-repository.ts
@@ -26,7 +26,8 @@ export class PasskeysCredentialsFileRepository implements PasskeysCredentialsRep
   deleteCredential(credential: PasskeyDiscoverableCredential): void {
     const id = getRepositoryId(credential);
     const filename = path.join(this.credentialsDir, `${id}.json`);
-    fs.unlink(filename, () => {});
+    // synchronous rm to avoid a race with future re-saves
+    fs.rmSync(filename, { force: true });
   }
   loadCredentials(): PasskeyDiscoverableCredential[] {
     const files = fs.readdirSync(this.credentialsDir);


### PR DESCRIPTION
I detected this when a persisted credential periodically disappeared from disk during heavy testing. Traced it to `getAssertion` updating signCount and then calling `saveCredential` which deletes the persisted credential asynchronously and saves the updated version. The async delete creates a race allowing the delete to sometimes happen after the re-save, resulting in a deleted credential.

I fixed this by making the delete synchronous, but another option would be to just overwrite the saved credential w/o deleting first. Since it seemed prudent to make the delete sync for other reasons, I chose that approach. 